### PR TITLE
[CRITICAL BUG] Moved babel to `dependencies` so our addon is actually transpiled in host apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,14 @@
   },
   "author": "Ben Lesh <blesh@netflix.com> and contributors",
   "license": "Apache 2",
+  "dependencies": {
+    "ember-cli-babel": "^5.0.0",
+  },
   "devDependencies": {
     "benchpress": "^2.0.0-alpha.16",
     "broccoli-asset-rev": "^2.0.0",
     "ember-cli": "0.2.0",
     "ember-cli-app-version": "0.3.2",
-    "ember-cli-babel": "^4.0.0",
     "ember-cli-dependency-checker": "0.0.8",
     "ember-cli-htmlbars": "0.7.4",
     "ember-cli-ic-ajax": "0.1.1",


### PR DESCRIPTION
This is causing consuming apps testing to fail and also not compatible in browsers that don't support the features we're using (Chrome does, Safari doesn't for example) because our addon will only be transpiled during testing of itself via npm install (devDeps).

https://github.com/ember-cli/ember-cli/pull/3564