### PR TITLE
Removed re-render bugs I could find

### DIFF
--- a/addon/mixins/graph-has-graph-parent.js
+++ b/addon/mixins/graph-has-graph-parent.js
@@ -20,12 +20,13 @@ export default Ember.Mixin.create({
   /**
     Initalization method that gets the `nf-graph` parent
     and assigns it to `graph`
-    
-    @method _getGraph
+    NOTE: all object that mixin and have init, must call super.init()
+    @method init
     */
-  _getGraph: Ember.on('init', function(){
+
+  init() {
+    this._super(...arguments);
     var graph = this.nearestWithProperty('isGraph');
     this.set('graph', graph);
-    this.trigger('hasGraph', graph);
-  }),
+  }
 });

--- a/addon/mixins/graph-requires-scale-source.js
+++ b/addon/mixins/graph-requires-scale-source.js
@@ -103,8 +103,9 @@ export default Ember.Mixin.create({
     return this._scaleOffsetY || 0;
   }),
 
-  _getScaleSource: Ember.on('init', function(){
+  init() {
+    this._super(...arguments);
     var scaleSource = this.nearestWithProperty('isScaleSource');
     this.set('scaleSource', scaleSource);
-  }),
+  }
 });

--- a/app/components/nf-area.js
+++ b/app/components/nf-area.js
@@ -54,13 +54,14 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
     */
     nextArea: null,
 
-    _checkForAreaStackParent: Ember.on('init', function() {
+    init() {
+      this._super(...arguments);
       var stack = this.nearestWithProperty('isAreaStack');
       if(stack) {
         stack.registerArea(this);
         this.set('stack', stack);
       }
-    }),
+    },
 
     _unregister: Ember.on('willDestroyElement', function(){
       var stack = this.get('stack', stack);

--- a/app/components/nf-bars.js
+++ b/app/components/nf-bars.js
@@ -147,12 +147,13 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
   */
   barClick: null,
 
-  _registerBars: Ember.on('init', function(){
+  init() {
+    this._super(...arguments);
     var group = this.nearestWithProperty('isBarsGroup');
     if(group && group.registerBars) {
       group.registerBars(this);
     }
-  }),
+  },
 
   actions: {
     nfBarClickBar: function(dataPoint) {

--- a/app/components/nf-graph-content.js
+++ b/app/components/nf-graph-content.js
@@ -158,7 +158,8 @@ export default Ember.Component.extend(HasGraphParent, {
   */
   frets: Ember.computed.alias('graph.xAxis.ticks'),
 
-  hasGraph: function(graph) {
-    graph.set('content', this);
+  init(){
+    this._super(...arguments);
+    this.set('graph.content', this);
   },
 });

--- a/app/components/nf-graph.js
+++ b/app/components/nf-graph.js
@@ -942,9 +942,10 @@ export default Ember.Component.extend({
     @method _setup
     @private
   */
-  _setup: Ember.on('init', function(){
+  init() {
+    this._super(...arguments);
     this.set('selected', this.selectMultiple ? Ember.A() : null);
-  }),
+  },
 
   /**
     The amount of leeway, in pixels, to give before triggering a brush start.

--- a/app/components/nf-range-marker.js
+++ b/app/components/nf-range-marker.js
@@ -173,11 +173,12 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @method _setup
     @private
   */
-  _setup: Ember.on('init', function(){
+  init() {
+    this._super(...arguments);
     var container = this.nearestWithProperty('isRangeMarkerContainer');
     container.registerMarker(this);
     this.set('container', container);
-  }),
+  },
 
   /**
     Unregisters the range marker from its parent when the range marker is destroyed.

--- a/app/components/nf-x-axis.js
+++ b/app/components/nf-x-axis.js
@@ -178,7 +178,7 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
 
   init() {
     this._super(...arguments);
-
+    this.set('graph.xAxis', this);
     Ember.deprecate('Non-block form of tick is deprecated. Please add `as |tick|` to your template.', this.get('template.blockParams'));
   },
 
@@ -267,15 +267,6 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
       return Ember.A(result);
     }
   ),
-
-  /**
-    Updates the graph's xAxis property on willInsertElement
-    @method _updateGraphXAxis
-    @private
-  */
-  _updateGraphXAxis: Ember.on('willInsertElement', function(){
-    this.set('graph.xAxis', this);
-  }),
 
   /**
     The y position, in pixels, of the axis line

--- a/app/components/nf-y-axis.js
+++ b/app/components/nf-y-axis.js
@@ -177,7 +177,7 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
 
   init() {
     this._super(...arguments);
-
+    this.set('graph.yAxis', this);
     Ember.deprecate('Non-block form of tick is deprecated. Please add `as |tick|` to your template.', this.get('template.blockParams'));
   },
 
@@ -268,13 +268,4 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
   axisLineX: Ember.computed('isOrientRight', 'width', function(){
     return this.get('isOrientRight') ? 0 : this.get('width');
   }),
-
-  /**
-    sets graph's yAxis property on willInsertElement
-    @method _updateGraphYAxis
-    @private
-  */
-  _updateGraphYAxis: Ember.on('willInsertElement', function(){
-    this.set('graph.yAxis', this);
-  })
 });

--- a/app/templates/components/nf-graph-content.hbs
+++ b/app/templates/components/nf-graph-content.hbs
@@ -1,6 +1,6 @@
 <rect x=0 y=0 class="background" {{bind-attr width=width height=height}}></rect>
 
-{{#if graph.hasRendered}}
+
   {{#if graph.hasData}}
     {{#if graph.showLanes}}
       <g class="nf-grid-lanes">
@@ -22,6 +22,6 @@
   {{#unless graph.hasData}}
     <text x=0 y=0>No data</text>
   {{/unless}}
-{{/if}}
+
 
 {{yield}}


### PR DESCRIPTION
So in no particular order:

- Any `willInsertElement` event that was registering components with one another causing re-render.
- All uses of `on('init')` that aren't tied to some observer are moved to just `init()` to prevent re-render
- Removed `hasRendered` check as it no longer seems necessary and was causing re-render. It was a legacy hack.