### PR TITLE
Fixes license to be a valid SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">= 0.10.0"
   },
   "author": "Ben Lesh <blesh@netflix.com> and contributors",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "dependencies": {
     "ember-cli-babel": "^5.0.0"
   },


### PR DESCRIPTION
npm is now requiring licenses to be a [SPDX expression](https://spdx.org/licenses/), so a warning is logged that ours is not compliant.

```bash
license should be a valid SPDX license expression
```
This fixes that.