### PR TITLE
fix #64 - tickFactory regression

### DIFF
--- a/app/components/nf-x-axis.js
+++ b/app/components/nf-x-axis.js
@@ -190,11 +190,41 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
   */
   width: Ember.computed.alias('graph.graphWidth'),
 
-  tickData: Ember.computed('xScale', 'graph.xScaleType', 'uniqueXData', 'tickCount', function(){
-    if(this.get('graph.xScaleType') === 'ordinal') {
-      return this.get('uniqueXData');
-    } else {
-      return this.get('xScale').ticks(this.get('tickCount'));
+  /**
+    A method to call to override the default behavior of how ticks are created.
+
+    The function signature should match:
+
+          // - scale: d3.Scale
+          // - tickCount: number of ticks
+          // - uniqueData: unique data points for the axis
+          // - scaleType: string of "linear" or "ordinal"
+          // returns: an array of tick values.
+          function(scale, tickCount, uniqueData, scaleType) {
+            return [100,200,300];
+          }
+
+    @property tickFactory
+    @type {Function}
+    @default null
+  */
+  tickFactory: null,
+
+  tickData: Ember.computed('xScale', 'graph.xScaleType', 'uniqueXData', 'tickCount', 'tickFactory', function(){
+    var tickFactory = this.get('tickFactory');
+    var scale = this.get('xScale');
+    var uniqueData = this.get('uniqueXData');
+    var tickCount = this.get('tickCount');
+    var scaleType = this.get('graph.xScaleType');
+
+    if(tickFactory) {
+      return tickFactory(scale, tickCount, uniqueData, scaleType);
+    }
+    else if(scaleType === 'ordinal') {
+      return uniqueData;
+    } 
+    else {
+      return scale.ticks(tickCount);
     }
   }),
 

--- a/tests/unit/app/components/nf-bars-test.js
+++ b/tests/unit/app/components/nf-bars-test.js
@@ -11,6 +11,7 @@ moduleForComponent('nf-bars', {
 });
 
 test('bars layout', function(assert) {
+  console.log(this);
   var nfBars = this.subject();
 
   nfBars.setProperties({

--- a/tests/unit/app/components/nf-x-axis-test.js
+++ b/tests/unit/app/components/nf-x-axis-test.js
@@ -1,0 +1,35 @@
+import Ember from 'ember';
+
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+
+moduleForComponent('nf-x-axis', {
+  // specify the other units that are required for this test
+  needs: ['component:nf-graph']
+});
+
+test('nf-x-axis tickData should call tickFactory if available', function(assert) {
+  var args;
+
+  //HACK: couldn't find a great, documented way of mocking readonly and aliased propertied
+  // so I override them here.
+  var axis = this.factory().extend({
+    uniqueXData: [1,2,3,4,5],
+    xScale: 'xScale',
+    graph: Ember.computed((key, value) => ({
+      xScaleType: 'xScaleType'
+    })),
+    tickCount: 42,
+    tickFactory: function() {
+      args = [].slice.call(arguments);
+      return 'expected result';
+    }
+  }).create();
+
+  var tickData = axis.get('tickData');
+  assert.equal(tickData, 'expected result');
+  assert.deepEqual(args, ['xScale', 42, [1,2,3,4,5], 'xScaleType']);
+});

--- a/tests/unit/app/components/nf-y-axis-test.js
+++ b/tests/unit/app/components/nf-y-axis-test.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+
+moduleForComponent('nf-y-axis', {
+  // specify the other units that are required for this test
+  needs: ['component:nf-graph']
+});
+
+test('nf-y-axis tickData should call tickFactory if available', function(assert) {
+  var args;
+
+  //HACK: couldn't find a great, documented way of mocking readonly and aliased propertied
+  // so I override them here.
+  var axis = this.factory().extend({
+    uniqueYData: [1,2,3,4,5],
+    yScale: 'yScale',
+    graph: Ember.computed((key, value) => ({
+      yScaleType: 'yScaleType'
+    })),
+    tickCount: 42,
+    tickFactory: function() {
+      args = [].slice.call(arguments);
+      return 'expected result';
+    }
+  }).create();
+
+  var tickData = axis.get('tickData');
+  assert.equal(tickData, 'expected result');
+  assert.deepEqual(args, ['yScale', 42, [1,2,3,4,5], 'yScaleType']);
+});


### PR DESCRIPTION
@jayphelps - please look at the unit tests for this. I had to get hacky, because I couldn't find a great way to mock the `uniq` and `alias` properties, so I ended up subclassing just to override those properties for my test. Works... but feels gross.