### PR TITLE
remove {{bind-attr}} everywhere

### DIFF
--- a/app/templates/components/nf-area.hbs
+++ b/app/templates/components/nf-area.hbs
@@ -1,4 +1,4 @@
-<path class="area" {{bind-attr d=d}}></path>
+<path class="area" d="{{d}}"></path>
 {{#if showTrackingDot}}
 	{{nf-dot x=trackedData.x y=trackedData.y r=trackingDotRadius multiplierY=multiplierY multiplierX=multiplierX}}
 {{/if}}

--- a/app/templates/components/nf-bars.hbs
+++ b/app/templates/components/nf-bars.hbs
@@ -1,3 +1,3 @@
 {{#each bar in bars}}
-	<path {{bind-attr d=bar.path class=bar.className}} {{action 'nfBarClickBar' bar.data bar.index}}></path>
+	<path d="{{bar.path}}" class="{{bar.className}}" {{action 'nfBarClickBar' bar.data bar.index}}></path>
 {{/each}}

--- a/app/templates/components/nf-brush-selection.hbs
+++ b/app/templates/components/nf-brush-selection.hbs
@@ -1,8 +1,8 @@
-<rect class="nf-brush-selection-overlay" x="0" y="0" {{bind-attr width=leftX height=graphHeight}}></rect>
-<rect class="nf-brush-selection-overlay" y="0" {{bind-attr x=rightX width=rightWidth height=graphHeight}}></rect>
+<rect class="nf-brush-selection-overlay" x="0" y="0" width="{{leftX}}" height="{{graphHeight}}"></rect>
+<rect class="nf-brush-selection-overlay" y="0" x="{{rightX}}" width="{{rightWidth}}" height="{{graphHeight}}"></rect>
 
-<line class="nf-brush-selection-line" y1="0" {{bind-attr x1=leftX x2=leftX y2=graphHeight}}></line>
-<line class="nf-brush-selection-line" y1="0" {{bind-attr x1=rightX x2=rightX y2=graphHeight}}></line>
+<line class="nf-brush-selection-line" y1="0" x1="{{leftX}}" x2="{{leftX}}" y2="{{graphHeight}}"></line>
+<line class="nf-brush-selection-line" y1="0" x1="{{rightX}}" x2="{{rightX}}" y2="{{graphHeight}}"></line>
 
 <g class="nf-brush-selection-left-display">
 	<rect class="nf-brush-selection-left-text-bg"></rect>

--- a/app/templates/components/nf-crosshair.hbs
+++ b/app/templates/components/nf-crosshair.hbs
@@ -1,3 +1,2 @@
-<line class="vertical"  {{bind-attr x1=x x2=x y1="0" y2=height}} />
-<line class="horizontal" {{bind-attr x1="0" x2=width y1=y y2=y}} />
-
+<line class="vertical" x1="{{x}}" x2="{{x}}" y1="0" y2="{{height}}" />
+<line class="horizontal" x1="0" x2="{{width}}" y1="{{y}}" y2="{{y}}" />

--- a/app/templates/components/nf-graph-content.hbs
+++ b/app/templates/components/nf-graph-content.hbs
@@ -1,11 +1,11 @@
-<rect x=0 y=0 class="background" {{bind-attr width=width height=height}}></rect>
+<rect x=0 y=0 class="background" width="{{width}}" height="{{height}}"></rect>
 
 
   {{#if graph.hasData}}
     {{#if graph.showLanes}}
       <g class="nf-grid-lanes">
         {{#each lane in gridLanes}}
-          <rect {{bind-attr x=lane.x y=lane.y width=width height=lane.height }}></rect>
+          <rect x="{{lane.x}}" y="{{lane.y}}" width="{{width}}" height="{{lane.height}}"></rect>
         {{/each}}
       </g>
     {{/if}}
@@ -13,7 +13,7 @@
     {{#if graph.showFrets}}
       <g class="nf-grid-frets">
         {{#each fret in frets}}
-          <line {{bind-attr x1=fret.x y1="0" x2=fret.x y2=height}}></line>
+          <line x1="{{fret.x}}" y1="0" x2="{{fret.x}}" y2="{{height}}"></line>
         {{/each}}
       </g>
     {{/if}}

--- a/app/templates/components/nf-graph.hbs
+++ b/app/templates/components/nf-graph.hbs
@@ -1,12 +1,12 @@
-<svg class="nf-graph" {{bind-attr width=width height=height}}>
+<svg class="nf-graph" width="{{width}}" height="{{height}}">
 	<defs>
-		<clipPath {{bind-attr id=contentClipPathId}}>
-			<rect x=0 y=0 {{bind-attr width=graphWidth height=graphHeight}}></rect>
+		<clipPath id="{{contentClipPathId}}">
+			<rect x=0 y=0 width="{{graphWidth}}" height="{{graphHeight}}"></rect>
 		</clipPath>
 	</defs>
 
-	<rect class="background" x=0 y=0 {{bind-attr width=width height=height}}></rect>
-  
+	<rect class="background" x=0 y=0 width="{{width}}" height="{{height}}"></rect>
+
   {{yield}}
 
 

--- a/app/templates/components/nf-line.hbs
+++ b/app/templates/components/nf-line.hbs
@@ -1,6 +1,6 @@
-<path class="line" {{bind-attr d=d}}></path>
+<path class="line" d="{{d}}"></path>
 {{#if selectable}}
-	<path class="interaction-mask" {{bind-attr d=d}}></path>
+	<path class="interaction-mask" d="{{d}}"></path>
 {{/if}}
 
 {{#if showTrackingDot}}

--- a/app/templates/components/nf-range-marker.hbs
+++ b/app/templates/components/nf-range-marker.hbs
@@ -1,2 +1,2 @@
-<g class="label" {{bind-attr transform=labelTransform}}>{{yield}}</g>
-<rect {{bind-attr y=marginTop x=x width=width height=height}}></rect>
+<g class="label" transform="{{labelTransform}}">{{yield}}</g>
+<rect y="{{marginTop}}" x="{{x}}" width="{{width}}" height="{{height}}"></rect>

--- a/app/templates/components/nf-right-tick.hbs
+++ b/app/templates/components/nf-right-tick.hbs
@@ -1,2 +1,2 @@
-<line {{bind-attr x1=graph.width x2=graph.width y1="0" y2=graph.height}}></line>
+<line x1="{{graph.width}}" x2="{{graph.width}}" y1="0" y2="{{graph.height}}"></line>
 <path d="M6,0 0,6 6,12"></path>


### PR DESCRIPTION
`{{bind-attr foo=bar}}` has ben deprecated in favor of `foo="{{bar}}"`.

Merging this this would mean changing the support matrix for the addon as {{bind-attr}} requires at least Ember 1.11

(#72 has the `bind-attr` cleanup for the axes components.)