### PR TITLE
Stack area changes

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -18,4 +18,6 @@ var app = new EmberAddon();
 // please specify an object with the list of modules as keys
 // along with the exports of each module as its value.
 
+app.import('bower_components/ember/ember-template-compiler.js', { type: 'test' });
+
 module.exports = app.toTree();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### master
+
+- ADD `nf-tracker` component. This is a component for templatable tracking dots
+- UPDATE `nf-line` and `nf-area` to use `nf-tracker` for tracking dot generation
+- UPDATE improved performance on hover/tracking
+- UPDATE add `aggregate` to `nf-area-stack` component to sum y values of areas for stacking purposes. Defaults to `false` currently, but should be used with `true` from this point on, as it will default to `true` in future versions.
+- UPDATE switch templates to attribute syntax
+- UPDATE switch most computed properties to new computed property syntax
+- FIX nf-graph should work with Glimmer now (thanks @jamesarosen)
+
 ### v1.0.0-beta.16
 
 - FIX [#64](https://github.com/Netflix/ember-nf-graph/issues/64) put `tickFactory` back where it belongs on the axes components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - UPDATE switch templates to attribute syntax
 - UPDATE switch most computed properties to new computed property syntax
 - FIX nf-graph should work with Glimmer now (thanks @jamesarosen)
+- BREAKING graph components such as `nf-line` and `nf-area` will no longer sort your data for you. This is done for performance reasons.
 
 ### v1.0.0-beta.16
 

--- a/addon/mixins/graph-data-graphic.js
+++ b/addon/mixins/graph-data-graphic.js
@@ -35,12 +35,16 @@ export default Ember.Mixin.create({
     get() {
       var yPropFn = this.get('yPropFn');
       var xPropFn = this.get('xPropFn');
-      return this.get('data').map(function(d, i) {
-        var item = [xPropFn(d), yPropFn(d)];
-        item.data = d;
-        item.origIndex = i;
-        return item;
-      });
+      var data = this.get('data');
+      if(Ember.isArray(data)) {
+        return data.map(function(d, i) {
+          var item = [xPropFn(d), yPropFn(d)];
+          item.data = d;
+          item.origIndex = i;
+          return item;
+        });
+      }
+      return [];
     }
   }),
 

--- a/addon/mixins/graph-data-graphic.js
+++ b/addon/mixins/graph-data-graphic.js
@@ -3,6 +3,8 @@ import parsePropertyExpr from '../utils/parse-property-expression';
 import { nearestIndexTo } from '../utils/nf/array-helpers';
 import computed from 'ember-new-computed';
 
+var { on, observer } = Ember;
+
 var noop = function(){};
 
 /**
@@ -28,6 +30,27 @@ export default Ember.Mixin.create({
     @default null
   */
   data: null,
+
+  mappedData: computed('data.@each', {
+    get() {
+      var yPropFn = this.get('yPropFn');
+      var xPropFn = this.get('xPropFn');
+      return this.get('data').map(function(d, i) {
+        var item = [xPropFn(d), yPropFn(d)];
+        item.data = d;
+        item.origIndex = i;
+        return item;
+      });
+    }
+  }),
+
+  _triggerHasData: on('init', observer('data.@each', function(){
+    Ember.run.once(this, this._sendTriggerHasData);
+  })),
+
+  _sendTriggerHasData() {
+    this.trigger('hasData', this.get('mappedData'));
+  },
 
   /**
     The path of the property on each object in 
@@ -82,107 +105,37 @@ export default Ember.Mixin.create({
   }),
 
   /**
-    Gets the x values from the `sortedData`.
-    @property xData
-    @type Array
-    @readonly
-  */
-  xData: null,
-
-  /**
-    Gets the y values from the `sortedData`
-    @property yData
-    @type Array
-    @readonly
-  */
-  yData: null,
-
-  /**
-    The sorted and mapped data pulled from {{#crossLink "mixins.graph-data-graphic/data:property"}}{{/crossLink}}
-    An array of arrays, structures as so:
-
-          [[x,y],[x,y],[x,y]];
-
-    ** each inner array also has a property `data` on it, containing the original data object **
-
-    When this property is computed, it also updates the `xData` and `yData` properties of the graphic.
-    @property sortedData
-    @type Array
-    @readonly
-  */
-  sortedData: computed('data.@each', 'xPropFn', 'yPropFn', {
-    get() {
-      var data = this.get('data');
-      var xPropFn = this.get('xPropFn');
-      var yPropFn = this.get('yPropFn');
-      var xScaleType = this.get('xScaleType');
-
-      if(!data) {
-        return null;
-      }
-
-      var mapped = data.map(function(d, i) {
-        var item = [xPropFn(d), yPropFn(d)];
-        item.data = d;
-        item.origIndex = i;
-        return item;
-      });
-
-      if(xScaleType !== 'ordinal') {
-        mapped.sort(function(a, b) {
-          var ax = a[0];
-          var bx = b[0];
-          return ax === bx ? 0 : (ax > bx) ? 1 : -1;
-        });
-      }
-
-      var xData = [];
-      var yData = [];
-      
-      mapped.forEach(function(d) {
-        xData.push(d[0]);
-        yData.push(d[1]);
-      });
-
-      this.set('xData', xData);
-      this.set('yData', yData);
-      
-      return mapped;
-    }
-  }),
-
-  /**
-    The list of data points from {{#crossLink "mixins.graph-data-graphc/sortedData:property"}}{{/crossLink}} that
+    The list of data points from {{#crossLink "mixins.graph-data-graphc/mappedData:property"}}{{/crossLink}} that
     fits within the x domain, plus up to one data point outside of that domain in each direction.
     @property renderedData
     @type Array
     @readonly
   */
   renderedData: computed(
-    'sortedData.@each',
+    'mappedData.@each',
     'graph.xScaleType',
     'graph.xMin',
     'graph.xMax',
     {
       get() {
-        var sortedData = this.get('sortedData');
+        var mappedData = this.get('mappedData');
         var graph = this.get('graph');
         var xScaleType = graph.get('xScaleType');
         var xMin = graph.get('xMin');
         var xMax = graph.get('xMax');
 
-        if(!sortedData || sortedData.length === 0) {
+        if(!mappedData || mappedData.length === 0) {
           return [];
         }
 
         if(xScaleType === 'ordinal') {
-          return sortedData.slice();
+          return mappedData;
         }
 
-        return sortedData.filter(function(d, i) {
+        return mappedData.filter(function(d, i) {
           var x = d[0];
-          var prev = sortedData[i-1];
-          var next = sortedData[i+1];
+          var prev = mappedData[i-1];
+          var next = mappedData[i+1];
           var prevX = prev ? prev[0] : null;
           var nextX = next ? next[0] : null;
 

--- a/app/components/nf-area-stack.js
+++ b/app/components/nf-area-stack.js
@@ -35,6 +35,22 @@ export default Ember.Component.extend({
   isAreaStack: true,
 
   /**
+    Whether or not to add the values together to create the stacked area
+    @property aggregate
+    @type {boolean}
+    @default false
+  */
+  aggregate: Ember.computed(function(key, value) {
+    if(arguments.length > 1) {
+      this._aggregate = value;
+    } else if(typeof this._aggregate === 'undefined') {
+      Ember.warn('nf-area-stack.aggregate must be set. Currently defaulting to `false` but will default to `true` in the future.')
+      this._aggregate = false;
+    }
+    return this._aggregate;
+  }),
+
+  /**
     The collection of `nf-area` components under this stack.
     @property areas
     @type Array

--- a/app/components/nf-area.js
+++ b/app/components/nf-area.js
@@ -99,11 +99,11 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
       @type Array
       @readonly
     */
-    areaData: Ember.computed('renderedData.@each', 'nextYData.@each', function(){
+    areaData: Ember.computed('renderedData.[]', 'nextYData.@each', 'stack.aggregate', function() {
       var nextYData = this.get('nextYData');
-      return this.get('renderedData').map(function(r, i) {
-        return [r[0], r[1], nextYData[i]];
-      });
+      var renderedData = this.get('renderedData');
+      var aggregate = this.get('stack.aggregate');
+      return renderedData.map(([x, y], i) => aggregate ? [x, y + nextYData[i], nextYData[i]] : [x, y, nextYData[i]]);
     }),
 
 

--- a/app/components/nf-area.js
+++ b/app/components/nf-area.js
@@ -78,32 +78,30 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
       @type Array
       @readonly
     */
-    nextYData: Ember.computed('renderedData.length', 'nextArea.renderedData.@each', function(){
-      var nextData = this.get('nextArea.renderedData') || [];
-      var renderedDataLength = this.get('renderedData.length');
-        
-      var result = nextData.map(function(next) {
-        return next[1];
-      });
-      
-      while(result.length < renderedDataLength) {
-        result.push(-99999999);
+    nextYData: Ember.computed('data.length', 'nextArea.data.@each', function(){
+      var data = this.get('data');
+      if(!Array.isArray(data)) {
+        return [];
       }
-
-      return result;
+      var nextData = this.get('nextArea.mappedData');
+      return data.map((d, i) => (nextData && nextData[i] && nextData[i][1]) || Number.MIN_VALUE);
     }),
 
     /**
       The current rendered data "zipped" together with the nextYData.
-      @property areaData
+      @property mappedData
       @type Array
       @readonly
     */
-    areaData: Ember.computed('renderedData.[]', 'nextYData.@each', 'stack.aggregate', function() {
-      var nextYData = this.get('nextYData');
-      var renderedData = this.get('renderedData');
+    mappedData: Ember.computed('data.[]', 'xPropFn', 'yPropFn', 'nextYData.@each', 'stack.aggregate', function() {
+      var { data, xPropFn, yPropFn, nextYData } = this.getProperties('data', 'xPropFn', 'yPropFn', 'nextYData');
       var aggregate = this.get('stack.aggregate');
-      return renderedData.map(([x, y], i) => aggregate ? [x, y + nextYData[i], nextYData[i]] : [x, y, nextYData[i]]);
+      return data.map((d, i) => {
+        var x = xPropFn(d);
+        var y = yPropFn(d);
+        var result = aggregate ? [x, y + nextYData[i], nextYData[i]] : [x, y, nextYData[i]];
+        return result;
+      });
     }),
 
 
@@ -126,9 +124,9 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
       @type String
       @readonly
     */
-    d: Ember.computed('areaData', 'areaFn', function(){
-      var areaData = this.get('areaData');
-      return this.get('areaFn')(areaData);
+    d: Ember.computed('renderedData', 'areaFn', function(){
+      var renderedData = this.get('renderedData');
+      return this.get('areaFn')(renderedData);
     }),
 
     click: function(){

--- a/app/components/nf-tracker.js
+++ b/app/components/nf-tracker.js
@@ -12,6 +12,9 @@ const { or } = Ember.computed;
   A tracking graphic component used to do things like create tracking dots for nf-area or nf-line.
   @namespace components
   @class nf-tracker
+  @uses mixins.graph-has-graph-parent
+  @uses mixins.graph-data-graphic
+  @uses mixins.graph-requires-scale-source
   */
 export default Ember.Component.extend(HasGraphParent, DataGraphic, RequiresScaleSource, {
   tagName: 'g',

--- a/app/components/nf-tracker.js
+++ b/app/components/nf-tracker.js
@@ -1,0 +1,284 @@
+import Ember from 'ember';
+import GraphMouseEvent from 'ember-nf-graph/utils/nf/graph-mouse-event';
+import DataGraphic from 'ember-nf-graph/mixins/graph-data-graphic';
+import RequiresScaleSource from 'ember-nf-graph/mixins/graph-requires-scale-source';
+import HasGraphParent from 'ember-nf-graph/mixins/graph-has-graph-parent';
+import computed from 'ember-new-computed';
+
+const get = Ember.get;
+const { or } = Ember.computed;
+
+/**
+  A tracking graphic component used to do things like create tracking dots for nf-area or nf-line.
+  @namespace components
+  @class nf-tracker
+  */
+export default Ember.Component.extend(HasGraphParent, DataGraphic, RequiresScaleSource, {
+  tagName: 'g',
+
+  classNameBindings: [':nf-tracker'],
+
+  attributeBindings: ['transform'],
+
+  /**
+    Gets or sets the tracking mode of the component.
+
+    Possible values are:
+
+    - 'hover': only track while mouse hover
+    - 'snap-last': track while mouse hover, but snap to the last data element when not hovering
+    - 'snap-first': track while mouse hover, but snap to the first data element when not hovering
+    - 'selected-hover': The same as `'hover'` tracking mode, but only when the compononent is 
+    {{#crossLink "mixins.graph-selectable-graphic/selected:property"}}{{/crossLink}}
+    - 'selected-snap-last': The same as `'snap-last'` tracking mode, but only when the compononent is 
+    {{#crossLink "mixins.graph-selectable-graphic/selected:property"}}{{/crossLink}}
+    - 'selected-snap-first': The same as `'snap-first'` tracking mode, but only when the compononent is 
+    {{#crossLink "mixins.graph-selectable-graphic/selected:property"}}{{/crossLink}}
+
+    @property trackingMode
+    @type String
+    @default 'hover'
+  */
+  trackingMode: 'hover',
+
+  isTracker: true,
+
+  trackedData: null,
+
+  isShouldTrack: or('isSelectedHoverMode', 'isHoverMode'),
+
+  isSelectedHoverMode: computed('trackingMode', {
+    get() {
+      var mode = this.get('trackingMode');
+      return mode === 'selected-hover' || mode === 'selected-snap-first' || mode === 'selected-snap-last';
+    }
+  }),
+
+  isHoverMode: computed('trackingMode', {
+    get() {
+      var mode = this.get('trackingMode');
+      return mode === 'hover' || mode === 'snap-first' || mode === 'snap-last';
+    }
+  }),
+
+  hoverData: null,
+
+  isHovered: false,
+
+  transform: computed('trackedData.x', 'trackedData.y', 'xScale', 'yScale', {
+    get() {
+      var xScale = this.get('xScale');
+      var yScale = this.get('yScale');
+      var x = xScale && xScale(this.get('trackedData.x') || 0);
+      var y = yScale && yScale(this.get('trackedData.y') || 0);
+      return 'translate(' + x + ',' + y + ')';
+    }
+  }),
+
+  showTracker: computed('trackedData.graphX', 'trackedData.graphY', {
+    get() {
+      var trackedData = this.get('trackedData');
+      if(trackedData) {
+        var x = get(trackedData, 'x');
+        var y = get(trackedData, 'y');
+        return +x === +x && +y === +y;
+      }
+    }
+  }),
+
+  _updateHovered: Ember.observer('isShouldTrack', 'hoverData', function(){
+    if(this.get('isShouldTrack')) {
+      this.set('trackedData', this.get('hoverData'));
+    }
+  }),
+
+  _processUpdateUnhovered: function(){
+    if(!this.get('isHovered')) {
+      var mode = this.get('trackingMode');
+      var selected = this.get('selected');
+      if(mode === 'snap-last' || (selected && mode === 'selected-snap-last')) {
+        this.set('trackedData', this.get('lastVisibleData'));
+      }
+      if(mode === 'snap-first' || (selected && mode === 'selected-snap-first')) {
+        this.set('trackedData', this.get('firstVisibleData'));
+      }
+    }
+  },
+
+  _updateUnhovered: Ember.on('didInsertElement', Ember.observer(
+    'isHovered',
+    'trackingMode',
+    'firstVisibleData',
+    'lastVisibleData',
+    'selected',
+    function(){
+      Ember.run.scheduleOnce('actions', this, this._processUpdateUnhovered);
+    }
+  )),
+
+  /**
+    The action name to send to the controller when the `hoverChange` event fires
+    @property hoverChange
+    @type String
+    @default null
+  */
+  hoverChange: null,
+
+  /**
+    Event handler for content hoverChange event. Triggers `didHoverChange`.
+    @method didContentHoverChange
+    @params e {utils.nf.graph-mouse-event}
+    @private
+  */
+  didContentHoverChange(e){
+    var graphContentElement = this.get('graphContentElement');
+
+    this.trigger('didHoverChange', GraphMouseEvent.create({
+      originalEvent: e.get('originalEvent'),
+      source: this,
+      graphContentElement: graphContentElement,
+    }));
+  },
+
+  /**
+    Event handler for didHoverChange. Sends hoverChange action.
+    @method didHoverChange
+    @param e {utils.nf.graph-mouse-event}
+  */
+  didHoverChange(e) {
+    var isHoverMode = this.get('isHoverMode');
+    var isSelectedHoverMode = this.get('isSelectedHoverMode');
+    var selected = this.get('selected');
+
+    if(!this.get('isHovered')) {
+      this.set('isHovered', true);
+    }
+
+    if(isHoverMode || (selected && isSelectedHoverMode)) {
+      this.set('hoverData', e);
+    }
+
+    if(this.get('hoverChange')) {
+      this.sendAction('hoverChange', e);
+    }
+  },
+
+  /**
+    Name of the action to send on `hoverEnd`
+    @property hoverEnd
+    @type String
+    @default null
+  */
+  hoverEnd: null,
+
+  /**
+    Event handler for didHoverEnd. Updates tracked data, and sends hoverEnd action.
+    @function didHoverEnd
+    @params e {Object} hover end event object.
+  */
+  didHoverEnd(e) {
+    this.set('hoverData', null);
+
+    if(this.get('isHovered')) {
+      this.set('isHovered', false);
+    }
+
+    if(this.get('hoverEnd')) {
+      this.sendAction('hoverEnd', {
+        originalEvent: e.get('originalEvent'),
+        source: this,
+        graph: this.get('graph'),
+      });
+    }
+  },
+
+  /**
+    The action to send on `didTrack`.
+    @property didTrack
+    @type String
+    @default null
+  */
+  didTrack: null,
+
+  /**
+    Observes changes to tracked data and sends the
+    didTrack action.
+    @method _sendDidTrack
+    @private
+  */
+  _sendDidTrack: Ember.observer('trackedData', function(){
+    if(this.get('didTrack')) {
+      this.sendAction('didTrack', {
+        x: this.get('trackedData.x'),
+        y: this.get('trackedData.y'),
+        data: this.get('trackedData.data'),
+        source: this,
+        graph: this.get('graph'),
+      });
+    }
+  }),
+
+  /**
+    The action to send on `willTrack`
+    @property willTrack
+    @type String
+    @default null
+  */
+  willTrack: null,
+
+  graphContentElement: computed('graph', {
+    get() {
+      return this.get('graph').$('.nf-graph-content')[0];
+    }
+  }),
+
+  /**
+    Observes impending changes to trackedData and sends
+    the willTrack action.
+    @method _sendWillTrack
+    @private
+  */
+  _sendWillTrack: Ember.beforeObserver('trackedData', function(){
+    if(this.get('willTrack')) {
+      this.sendAction('willTrack', {
+        x: this.get('trackedData.x'),
+        y: this.get('trackedData.y'),
+        data: this.get('trackedData.data'),
+        source: this,
+        graph: this.get('graph'),
+      });
+    }
+  }),
+
+  /**
+    Handles the graph-content's hoverEnd event and triggers didHoverEnd
+    @method didContentHoverEnd
+    @param e {utils.nf.graph-mouse-action-context}
+    @private
+  */
+  didContentHoverEnd(e){
+    var graph = this.get('graph');
+
+    this.trigger('didHoverEnd', {
+      originalEvent: e,
+      source: this,
+      graph: graph,
+    });
+  },
+
+  didInsertElement() {
+    this._super.apply(arguments);
+    var content = this.get('graph.content');
+    content.on('didHoverChange', this, this.didContentHoverChange);
+    content.on('didHoverEnd', this, this.didContentHoverEnd);
+  },
+
+  willDestroyElement(){
+    this._super.apply(arguments);
+    var content = this.get('graph.content');
+    if(content) {
+      content.off('didHoverChange', this, this.didContentHoverChange);
+      content.off('didHoverEnd', this, this.didContentHoverEnd);
+    }
+  }
+});

--- a/app/templates/components/nf-tracker.hbs
+++ b/app/templates/components/nf-tracker.hbs
@@ -1,0 +1,1 @@
+{{yield trackedData}}

--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "ember": "1.11.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
+    "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
-    "ember-qunit": "0.3.1",
+    "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",
@@ -13,5 +13,11 @@
     "qunit": "~1.17.1",
     "d3": "~3.5.5",
     "rxjs": "~2.3.24"
+  },
+  "resolutions": {
+    "ember-qunit": "~0.4.0"
+  },
+  "devDependencies": {
+    "ember-qunit": "~0.4.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
-    "ember-qunit": "0.3.3",
+    "ember-qunit": "~0.4.0",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",
@@ -13,11 +13,5 @@
     "qunit": "~1.17.1",
     "d3": "~3.5.5",
     "rxjs": "~2.3.24"
-  },
-  "resolutions": {
-    "ember-qunit": "~0.4.0"
-  },
-  "devDependencies": {
-    "ember-qunit": "~0.4.0"
   }
 }

--- a/docs/api.js
+++ b/docs/api.js
@@ -20,6 +20,7 @@ YUI.add("yuidoc-meta", function(Y) {
         "components.nf-svg-line",
         "components.nf-svg-path",
         "components.nf-svg-rect",
+        "components.nf-tracker",
         "components.nf-vertical-line",
         "components.nf-x-axis",
         "components.nf-y-axis",

--- a/docs/classes/components.nf-area-stack.html
+++ b/docs/classes/components.nf-area-stack.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -177,6 +178,10 @@ of each <code>nf-area</code> components path to be drawn.</p>
 
                     <ul class="index-list properties">
                             <li class="index-item property">
+                                <a href="#property_aggregate">aggregate</a>
+
+                            </li>
+                            <li class="index-item property">
                                 <a href="#property_areas">areas</a>
 
                             </li>
@@ -214,7 +219,7 @@ of each <code>nf-area</code> components path to be drawn.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-area-stack.js.html#l47"><code>app&#x2F;components&#x2F;nf-area-stack.js:47</code></a>
+        <a href="../files/app_components_nf-area-stack.js.html#l63"><code>app&#x2F;components&#x2F;nf-area-stack.js:63</code></a>
         </p>
 
 
@@ -269,7 +274,7 @@ another by setting <code>nextArea</code> on each area component.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-area-stack.js.html#l65"><code>app&#x2F;components&#x2F;nf-area-stack.js:65</code></a>
+        <a href="../files/app_components_nf-area-stack.js.html#l81"><code>app&#x2F;components&#x2F;nf-area-stack.js:81</code></a>
         </p>
 
 
@@ -308,6 +313,32 @@ and previous links.</p>
             <div id="properties" class="api-class-tabpanel">
                 <h2 class="off-left">Properties</h2>
 
+                    <div id="property_aggregate" class="property item">
+                        <h3 class="name"><code>aggregate</code></h3>
+                        <span class="type">Boolean</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>
+                                    Defined in
+                            <a href="../files/app_components_nf-area-stack.js.html#l37"><code>app&#x2F;components&#x2F;nf-area-stack.js:37</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>Whether or not to add the values together to create the stacked area</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> false</p>
+                    
+                    
+                    </div>
                     <div id="property_areas" class="property item">
                         <h3 class="name"><code>areas</code></h3>
                         <span class="type">Array</span>
@@ -319,7 +350,7 @@ and previous links.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-area-stack.js.html#l37"><code>app&#x2F;components&#x2F;nf-area-stack.js:37</code></a>
+                            <a href="../files/app_components_nf-area-stack.js.html#l53"><code>app&#x2F;components&#x2F;nf-area-stack.js:53</code></a>
                             </p>
                     
                     

--- a/docs/classes/components.nf-area.html
+++ b/docs/classes/components.nf-area.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -221,10 +222,6 @@ sibling <code>nf-area</code> components to create a stacked graph.</p>
 
                     <ul class="index-list properties extends">
                             <li class="index-item property">
-                                <a href="#property_areaData">areaData</a>
-
-                            </li>
-                            <li class="index-item property">
                                 <a href="#property_areaFn">areaFn</a>
 
                             </li>
@@ -270,6 +267,10 @@ sibling <code>nf-area</code> components to create a stacked graph.</p>
 
                             </li>
                             <li class="index-item property">
+                                <a href="#property_mappedData">mappedData</a>
+
+                            </li>
+                            <li class="index-item property">
                                 <a href="#property_nextArea">nextArea</a>
 
                             </li>
@@ -310,19 +311,11 @@ sibling <code>nf-area</code> components to create a stacked graph.</p>
 
                             </li>
                             <li class="index-item property inherited">
-                                <a href="#property_sortedData">sortedData</a>
-
-                            </li>
-                            <li class="index-item property inherited">
                                 <a href="#property_trackingMode">trackingMode</a>
 
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_willTrack">willTrack</a>
-
-                            </li>
-                            <li class="index-item property inherited">
-                                <a href="#property_xData">xData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -335,10 +328,6 @@ sibling <code>nf-area</code> components to create a stacked graph.</p>
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_xScale">xScale</a>
-
-                            </li>
-                            <li class="index-item property inherited">
-                                <a href="#property_yData">yData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -906,31 +895,6 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
             <div id="properties" class="api-class-tabpanel">
                 <h2 class="off-left">Properties</h2>
 
-                    <div id="property_areaData" class="property item">
-                        <h3 class="name"><code>areaData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/app_components_nf-area.js.html#l96"><code>app&#x2F;components&#x2F;nf-area.js:96</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>The current rendered data &quot;zipped&quot; together with the nextYData.</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
                     <div id="property_areaFn" class="property item">
                         <h3 class="name"><code>areaFn</code></h3>
                         <span class="type">Function</span>
@@ -942,7 +906,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-area.js.html#l110"><code>app&#x2F;components&#x2F;nf-area.js:110</code></a>
+                            <a href="../files/app_components_nf-area.js.html#l108"><code>app&#x2F;components&#x2F;nf-area.js:108</code></a>
                             </p>
                     
                     
@@ -967,7 +931,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-area.js.html#l123"><code>app&#x2F;components&#x2F;nf-area.js:123</code></a>
+                            <a href="../files/app_components_nf-area.js.html#l121"><code>app&#x2F;components&#x2F;nf-area.js:121</code></a>
                             </p>
                     
                     
@@ -992,7 +956,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_data">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l23"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:23</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l25"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:25</code></a>
                             </p>
                     
                     
@@ -1044,7 +1008,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_firstSortedData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l195"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:195</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l152"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:152</code></a>
                             </p>
                     
                     
@@ -1201,7 +1165,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_lastVisibleData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l219"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:219</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l176"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:176</code></a>
                             </p>
                     
                     
@@ -1210,6 +1174,31 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="description">
                             <p>&lt;p&gt;The last element from &lt;a href=&quot;../classes/mixins.graph-data-graphic.html#property_renderedData&quot; class=&quot;crosslink&quot;&gt;renderedData&lt;/a&gt;
                     that is actually visible within the x domain.&lt;/p&gt;</p>
+                    
+                        </div>
+                    
+                    
+                    
+                    </div>
+                    <div id="property_mappedData" class="property item">
+                        <h3 class="name"><code>mappedData</code></h3>
+                        <span class="type">Array</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>
+                                    Defined in
+                            <a href="../files/app_components_nf-area.js.html#l90"><code>app&#x2F;components&#x2F;nf-area.js:90</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The current rendered data &quot;zipped&quot; together with the nextYData.</p>
                     
                         </div>
                     
@@ -1306,14 +1295,14 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_renderedData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l154"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:154</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l111"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:111</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>&lt;p&gt;The list of data points from mixins.graph-data-graphc/sortedData:property that
+                            <p>&lt;p&gt;The list of data points from mixins.graph-data-graphc/mappedData:property that
                     fits within the x domain, plus up to one data point outside of that domain in each direction.&lt;/p&gt;</p>
                     
                         </div>
@@ -1479,36 +1468,6 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                     
                     
                     </div>
-                    <div id="property_sortedData" class="property item inherited">
-                        <h3 class="name"><code>sortedData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>Inherited from
-                                    <a href="../classes/mixins.graph-data-graphic.html#property_sortedData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l100"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:100</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>&lt;p&gt;The sorted and mapped data pulled from &lt;a href=&quot;../classes/mixins.graph-data-graphic.html#property_data&quot; class=&quot;crosslink&quot;&gt;data&lt;/a&gt;
-                    An array of arrays, structures as so:&lt;/p&gt;
-                    &lt;pre&gt;&lt;code&gt;  [[x,y],[x,y],[x,y]];
-                    &lt;/code&gt;&lt;/pre&gt;
-                    &lt;p&gt;** each inner array also has a property &lt;code&gt;data&lt;/code&gt; on it, containing the original data object **&lt;/p&gt;
-                    &lt;p&gt;When this property is computed, it also updates the &lt;code&gt;xData&lt;/code&gt; and &lt;code&gt;yData&lt;/code&gt; properties of the graphic.&lt;/p&gt;</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
                     <div id="property_trackingMode" class="property item inherited">
                         <h3 class="name"><code>trackingMode</code></h3>
                         <span class="type">String</span>
@@ -1574,31 +1533,6 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                     
                     
                     </div>
-                    <div id="property_xData" class="property item inherited">
-                        <h3 class="name"><code>xData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>Inherited from
-                                    <a href="../classes/mixins.graph-data-graphic.html#property_xData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l84"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:84</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>&lt;p&gt;Gets the x values from the &lt;code&gt;sortedData&lt;/code&gt;.&lt;/p&gt;</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
                     <div id="property_xprop" class="property item inherited">
                         <h3 class="name"><code>xprop</code></h3>
                         <span class="type">String</span>
@@ -1610,7 +1544,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_xprop">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l32"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:32</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l59"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:59</code></a>
                             </p>
                     
                     
@@ -1638,7 +1572,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_xPropFn">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l54"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:54</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l81"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:81</code></a>
                             </p>
                     
                     
@@ -1678,31 +1612,6 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                     
                     
                     </div>
-                    <div id="property_yData" class="property item inherited">
-                        <h3 class="name"><code>yData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>Inherited from
-                                    <a href="../classes/mixins.graph-data-graphic.html#property_yData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l92"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:92</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>&lt;p&gt;Gets the y values from the &lt;code&gt;sortedData&lt;/code&gt;&lt;/p&gt;</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
                     <div id="property_yprop" class="property item inherited">
                         <h3 class="name"><code>yprop</code></h3>
                         <span class="type">String</span>
@@ -1714,7 +1623,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_yprop">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l43"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:43</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l70"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:70</code></a>
                             </p>
                     
                     
@@ -1742,7 +1651,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_yPropFn">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l69"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:69</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l96"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:96</code></a>
                             </p>
                     
                     

--- a/docs/classes/components.nf-bars.html
+++ b/docs/classes/components.nf-bars.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -249,14 +250,6 @@
 
                             </li>
                             <li class="index-item property inherited">
-                                <a href="#property_sortedData">sortedData</a>
-
-                            </li>
-                            <li class="index-item property inherited">
-                                <a href="#property_xData">xData</a>
-
-                            </li>
-                            <li class="index-item property inherited">
                                 <a href="#property_xprop">xprop</a>
 
                             </li>
@@ -266,10 +259,6 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_xScale">xScale</a>
-
-                            </li>
-                            <li class="index-item property inherited">
-                                <a href="#property_yData">yData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -502,7 +491,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_data">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l23"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:23</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l25"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:25</code></a>
                             </p>
                     
                     
@@ -528,7 +517,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_firstSortedData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l195"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:195</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l152"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:152</code></a>
                             </p>
                     
                     
@@ -683,7 +672,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_lastVisibleData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l219"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:219</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l176"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:176</code></a>
                             </p>
                     
                     
@@ -709,14 +698,14 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_renderedData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l154"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:154</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l111"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:111</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>&lt;p&gt;The list of data points from mixins.graph-data-graphc/sortedData:property that
+                            <p>&lt;p&gt;The list of data points from mixins.graph-data-graphc/mappedData:property that
                     fits within the x domain, plus up to one data point outside of that domain in each direction.&lt;/p&gt;</p>
                     
                         </div>
@@ -828,61 +817,6 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                     
                     
                     </div>
-                    <div id="property_sortedData" class="property item inherited">
-                        <h3 class="name"><code>sortedData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>Inherited from
-                                    <a href="../classes/mixins.graph-data-graphic.html#property_sortedData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l100"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:100</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>&lt;p&gt;The sorted and mapped data pulled from &lt;a href=&quot;../classes/mixins.graph-data-graphic.html#property_data&quot; class=&quot;crosslink&quot;&gt;data&lt;/a&gt;
-                    An array of arrays, structures as so:&lt;/p&gt;
-                    &lt;pre&gt;&lt;code&gt;  [[x,y],[x,y],[x,y]];
-                    &lt;/code&gt;&lt;/pre&gt;
-                    &lt;p&gt;** each inner array also has a property &lt;code&gt;data&lt;/code&gt; on it, containing the original data object **&lt;/p&gt;
-                    &lt;p&gt;When this property is computed, it also updates the &lt;code&gt;xData&lt;/code&gt; and &lt;code&gt;yData&lt;/code&gt; properties of the graphic.&lt;/p&gt;</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
-                    <div id="property_xData" class="property item inherited">
-                        <h3 class="name"><code>xData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>Inherited from
-                                    <a href="../classes/mixins.graph-data-graphic.html#property_xData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l84"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:84</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>&lt;p&gt;Gets the x values from the &lt;code&gt;sortedData&lt;/code&gt;.&lt;/p&gt;</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
                     <div id="property_xprop" class="property item inherited">
                         <h3 class="name"><code>xprop</code></h3>
                         <span class="type">String</span>
@@ -894,7 +828,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_xprop">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l32"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:32</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l59"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:59</code></a>
                             </p>
                     
                     
@@ -922,7 +856,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_xPropFn">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l54"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:54</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l81"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:81</code></a>
                             </p>
                     
                     
@@ -962,31 +896,6 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                     
                     
                     </div>
-                    <div id="property_yData" class="property item inherited">
-                        <h3 class="name"><code>yData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>Inherited from
-                                    <a href="../classes/mixins.graph-data-graphic.html#property_yData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l92"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:92</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>&lt;p&gt;Gets the y values from the &lt;code&gt;sortedData&lt;/code&gt;&lt;/p&gt;</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
                     <div id="property_yprop" class="property item inherited">
                         <h3 class="name"><code>yprop</code></h3>
                         <span class="type">String</span>
@@ -998,7 +907,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_yprop">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l43"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:43</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l70"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:70</code></a>
                             </p>
                     
                     
@@ -1026,7 +935,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_yPropFn">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l69"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:69</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l96"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:96</code></a>
                             </p>
                     
                     

--- a/docs/classes/components.nf-crosshair.html
+++ b/docs/classes/components.nf-crosshair.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-dot.html
+++ b/docs/classes/components.nf-dot.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-gg.html
+++ b/docs/classes/components.nf-gg.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-graph-content.html
+++ b/docs/classes/components.nf-graph-content.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-graph.html
+++ b/docs/classes/components.nf-graph.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -143,11 +144,11 @@ plotting the data it finds on each object in the array <code>lineData</code> at 
 <code>foo</code> and <code>bar</code> for x and y values respectively.</p>
 <h2>More advanced example</h2>
 <pre class="code prettyprint"><code> {{#nf-graph width=500 height=300}}
-   {{#nf-x-axis height=&quot;50&quot;}}
+   {{#nf-x-axis height=&quot;50&quot; as |tick|}}
      &lt;text&gt;{{tick.value}}&lt;/text&gt;
    {{/nf-x-axis}}
 
-   {{#nf-y-axis width=&quot;120&quot;}}
+   {{#nf-y-axis width=&quot;120&quot; as |tick|}}
      &lt;text&gt;{{tick.value}}&lt;/text&gt;
    {{/nf-y-axis}}
 
@@ -494,7 +495,7 @@ render either axis unless its component is present.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-graph.js.html#l865"><code>app&#x2F;components&#x2F;nf-graph.js:865</code></a>
+        <a href="../files/app_components_nf-graph.js.html#l888"><code>app&#x2F;components&#x2F;nf-graph.js:888</code></a>
         </p>
 
 
@@ -526,7 +527,7 @@ render either axis unless its component is present.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-graph.js.html#l940"><code>app&#x2F;components&#x2F;nf-graph.js:940</code></a>
+        <a href="../files/app_components_nf-graph.js.html#l963"><code>app&#x2F;components&#x2F;nf-graph.js:963</code></a>
         </p>
 
 
@@ -563,7 +564,7 @@ render either axis unless its component is present.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-graph.js.html#l923"><code>app&#x2F;components&#x2F;nf-graph.js:923</code></a>
+        <a href="../files/app_components_nf-graph.js.html#l946"><code>app&#x2F;components&#x2F;nf-graph.js:946</code></a>
         </p>
 
 
@@ -623,7 +624,7 @@ render either axis unless its component is present.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-graph.js.html#l874"><code>app&#x2F;components&#x2F;nf-graph.js:874</code></a>
+        <a href="../files/app_components_nf-graph.js.html#l897"><code>app&#x2F;components&#x2F;nf-graph.js:897</code></a>
         </p>
 
 
@@ -697,7 +698,7 @@ render either axis unless its component is present.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-graph.js.html#l741"><code>app&#x2F;components&#x2F;nf-graph.js:741</code></a>
+        <a href="../files/app_components_nf-graph.js.html#l757"><code>app&#x2F;components&#x2F;nf-graph.js:757</code></a>
         </p>
 
 
@@ -751,7 +752,7 @@ render either axis unless its component is present.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-graph.js.html#l902"><code>app&#x2F;components&#x2F;nf-graph.js:902</code></a>
+        <a href="../files/app_components_nf-graph.js.html#l925"><code>app&#x2F;components&#x2F;nf-graph.js:925</code></a>
         </p>
 
 
@@ -806,7 +807,7 @@ selected graphic if it's different from the one passed.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-graph.js.html#l751"><code>app&#x2F;components&#x2F;nf-graph.js:751</code></a>
+        <a href="../files/app_components_nf-graph.js.html#l768"><code>app&#x2F;components&#x2F;nf-graph.js:768</code></a>
         </p>
 
 
@@ -959,7 +960,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l966"><code>app&#x2F;components&#x2F;nf-graph.js:966</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l989"><code>app&#x2F;components&#x2F;nf-graph.js:989</code></a>
                             </p>
                     
                     
@@ -985,7 +986,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l974"><code>app&#x2F;components&#x2F;nf-graph.js:974</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l997"><code>app&#x2F;components&#x2F;nf-graph.js:997</code></a>
                             </p>
                     
                     
@@ -1011,7 +1012,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l958"><code>app&#x2F;components&#x2F;nf-graph.js:958</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l981"><code>app&#x2F;components&#x2F;nf-graph.js:981</code></a>
                             </p>
                     
                     
@@ -1037,7 +1038,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l950"><code>app&#x2F;components&#x2F;nf-graph.js:950</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l973"><code>app&#x2F;components&#x2F;nf-graph.js:973</code></a>
                             </p>
                     
                     
@@ -1064,7 +1065,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l649"><code>app&#x2F;components&#x2F;nf-graph.js:649</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l665"><code>app&#x2F;components&#x2F;nf-graph.js:665</code></a>
                             </p>
                     
                     
@@ -1089,7 +1090,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l839"><code>app&#x2F;components&#x2F;nf-graph.js:839</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l862"><code>app&#x2F;components&#x2F;nf-graph.js:862</code></a>
                             </p>
                     
                     
@@ -1114,7 +1115,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l660"><code>app&#x2F;components&#x2F;nf-graph.js:660</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l676"><code>app&#x2F;components&#x2F;nf-graph.js:676</code></a>
                             </p>
                     
                     
@@ -1140,7 +1141,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l853"><code>app&#x2F;components&#x2F;nf-graph.js:853</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l876"><code>app&#x2F;components&#x2F;nf-graph.js:876</code></a>
                             </p>
                     
                     
@@ -1165,7 +1166,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l825"><code>app&#x2F;components&#x2F;nf-graph.js:825</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l848"><code>app&#x2F;components&#x2F;nf-graph.js:848</code></a>
                             </p>
                     
                     
@@ -1190,7 +1191,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l793"><code>app&#x2F;components&#x2F;nf-graph.js:793</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l816"><code>app&#x2F;components&#x2F;nf-graph.js:816</code></a>
                             </p>
                     
                     
@@ -1215,7 +1216,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l809"><code>app&#x2F;components&#x2F;nf-graph.js:809</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l832"><code>app&#x2F;components&#x2F;nf-graph.js:832</code></a>
                             </p>
                     
                     
@@ -1240,7 +1241,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l783"><code>app&#x2F;components&#x2F;nf-graph.js:783</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l806"><code>app&#x2F;components&#x2F;nf-graph.js:806</code></a>
                             </p>
                     
                     
@@ -1474,7 +1475,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l894"><code>app&#x2F;components&#x2F;nf-graph.js:894</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l917"><code>app&#x2F;components&#x2F;nf-graph.js:917</code></a>
                             </p>
                     
                     
@@ -1499,7 +1500,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l671"><code>app&#x2F;components&#x2F;nf-graph.js:671</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l687"><code>app&#x2F;components&#x2F;nf-graph.js:687</code></a>
                             </p>
                     
                     
@@ -1605,7 +1606,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l687"><code>app&#x2F;components&#x2F;nf-graph.js:687</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l703"><code>app&#x2F;components&#x2F;nf-graph.js:703</code></a>
                             </p>
                     
                     
@@ -1631,7 +1632,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l679"><code>app&#x2F;components&#x2F;nf-graph.js:679</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l695"><code>app&#x2F;components&#x2F;nf-graph.js:695</code></a>
                             </p>
                     
                     
@@ -1709,7 +1710,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l619"><code>app&#x2F;components&#x2F;nf-graph.js:619</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l635"><code>app&#x2F;components&#x2F;nf-graph.js:635</code></a>
                             </p>
                     
                     
@@ -1734,7 +1735,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l597"><code>app&#x2F;components&#x2F;nf-graph.js:597</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l613"><code>app&#x2F;components&#x2F;nf-graph.js:613</code></a>
                             </p>
                     
                     
@@ -1759,7 +1760,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l709"><code>app&#x2F;components&#x2F;nf-graph.js:709</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l725"><code>app&#x2F;components&#x2F;nf-graph.js:725</code></a>
                             </p>
                     
                     
@@ -2010,7 +2011,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l772"><code>app&#x2F;components&#x2F;nf-graph.js:772</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l795"><code>app&#x2F;components&#x2F;nf-graph.js:795</code></a>
                             </p>
                     
                     
@@ -2036,7 +2037,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l725"><code>app&#x2F;components&#x2F;nf-graph.js:725</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l741"><code>app&#x2F;components&#x2F;nf-graph.js:741</code></a>
                             </p>
                     
                     
@@ -2061,7 +2062,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l695"><code>app&#x2F;components&#x2F;nf-graph.js:695</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l711"><code>app&#x2F;components&#x2F;nf-graph.js:711</code></a>
                             </p>
                     
                     
@@ -2145,7 +2146,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l634"><code>app&#x2F;components&#x2F;nf-graph.js:634</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l650"><code>app&#x2F;components&#x2F;nf-graph.js:650</code></a>
                             </p>
                     
                     
@@ -2170,7 +2171,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l608"><code>app&#x2F;components&#x2F;nf-graph.js:608</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l624"><code>app&#x2F;components&#x2F;nf-graph.js:624</code></a>
                             </p>
                     
                     
@@ -2195,7 +2196,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l717"><code>app&#x2F;components&#x2F;nf-graph.js:717</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l733"><code>app&#x2F;components&#x2F;nf-graph.js:733</code></a>
                             </p>
                     
                     
@@ -2446,7 +2447,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l761"><code>app&#x2F;components&#x2F;nf-graph.js:761</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l784"><code>app&#x2F;components&#x2F;nf-graph.js:784</code></a>
                             </p>
                     
                     
@@ -2472,7 +2473,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l733"><code>app&#x2F;components&#x2F;nf-graph.js:733</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l749"><code>app&#x2F;components&#x2F;nf-graph.js:749</code></a>
                             </p>
                     
                     
@@ -2497,7 +2498,7 @@ selected graphic if it's different from the one passed.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-graph.js.html#l702"><code>app&#x2F;components&#x2F;nf-graph.js:702</code></a>
+                            <a href="../files/app_components_nf-graph.js.html#l718"><code>app&#x2F;components&#x2F;nf-graph.js:718</code></a>
                             </p>
                     
                     

--- a/docs/classes/components.nf-horizontal-line.html
+++ b/docs/classes/components.nf-horizontal-line.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-line.html
+++ b/docs/classes/components.nf-line.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -296,19 +297,11 @@
 
                             </li>
                             <li class="index-item property inherited">
-                                <a href="#property_sortedData">sortedData</a>
-
-                            </li>
-                            <li class="index-item property inherited">
                                 <a href="#property_trackingMode">trackingMode</a>
 
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_willTrack">willTrack</a>
-
-                            </li>
-                            <li class="index-item property inherited">
-                                <a href="#property_xData">xData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -321,10 +314,6 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_xScale">xScale</a>
-
-                            </li>
-                            <li class="index-item property inherited">
-                                <a href="#property_yData">yData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -1028,7 +1017,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_data">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l23"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:23</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l25"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:25</code></a>
                             </p>
                     
                     
@@ -1080,7 +1069,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_firstSortedData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l195"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:195</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l152"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:152</code></a>
                             </p>
                     
                     
@@ -1237,7 +1226,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_lastVisibleData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l219"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:219</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l176"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:176</code></a>
                             </p>
                     
                     
@@ -1263,14 +1252,14 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_renderedData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l154"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:154</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l111"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:111</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>&lt;p&gt;The list of data points from mixins.graph-data-graphc/sortedData:property that
+                            <p>&lt;p&gt;The list of data points from mixins.graph-data-graphc/mappedData:property that
                     fits within the x domain, plus up to one data point outside of that domain in each direction.&lt;/p&gt;</p>
                     
                         </div>
@@ -1436,36 +1425,6 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                     
                     
                     </div>
-                    <div id="property_sortedData" class="property item inherited">
-                        <h3 class="name"><code>sortedData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>Inherited from
-                                    <a href="../classes/mixins.graph-data-graphic.html#property_sortedData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l100"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:100</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>&lt;p&gt;The sorted and mapped data pulled from &lt;a href=&quot;../classes/mixins.graph-data-graphic.html#property_data&quot; class=&quot;crosslink&quot;&gt;data&lt;/a&gt;
-                    An array of arrays, structures as so:&lt;/p&gt;
-                    &lt;pre&gt;&lt;code&gt;  [[x,y],[x,y],[x,y]];
-                    &lt;/code&gt;&lt;/pre&gt;
-                    &lt;p&gt;** each inner array also has a property &lt;code&gt;data&lt;/code&gt; on it, containing the original data object **&lt;/p&gt;
-                    &lt;p&gt;When this property is computed, it also updates the &lt;code&gt;xData&lt;/code&gt; and &lt;code&gt;yData&lt;/code&gt; properties of the graphic.&lt;/p&gt;</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
                     <div id="property_trackingMode" class="property item inherited">
                         <h3 class="name"><code>trackingMode</code></h3>
                         <span class="type">String</span>
@@ -1531,31 +1490,6 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                     
                     
                     </div>
-                    <div id="property_xData" class="property item inherited">
-                        <h3 class="name"><code>xData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>Inherited from
-                                    <a href="../classes/mixins.graph-data-graphic.html#property_xData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l84"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:84</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>&lt;p&gt;Gets the x values from the &lt;code&gt;sortedData&lt;/code&gt;.&lt;/p&gt;</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
                     <div id="property_xprop" class="property item inherited">
                         <h3 class="name"><code>xprop</code></h3>
                         <span class="type">String</span>
@@ -1567,7 +1501,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_xprop">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l32"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:32</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l59"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:59</code></a>
                             </p>
                     
                     
@@ -1595,7 +1529,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_xPropFn">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l54"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:54</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l81"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:81</code></a>
                             </p>
                     
                     
@@ -1635,31 +1569,6 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                     
                     
                     </div>
-                    <div id="property_yData" class="property item inherited">
-                        <h3 class="name"><code>yData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>Inherited from
-                                    <a href="../classes/mixins.graph-data-graphic.html#property_yData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l92"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:92</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>&lt;p&gt;Gets the y values from the &lt;code&gt;sortedData&lt;/code&gt;&lt;/p&gt;</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
                     <div id="property_yprop" class="property item inherited">
                         <h3 class="name"><code>yprop</code></h3>
                         <span class="type">String</span>
@@ -1671,7 +1580,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_yprop">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l43"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:43</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l70"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:70</code></a>
                             </p>
                     
                     
@@ -1699,7 +1608,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_yPropFn">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l69"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:69</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l96"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:96</code></a>
                             </p>
                     
                     

--- a/docs/classes/components.nf-plot.html
+++ b/docs/classes/components.nf-plot.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-range-marker.html
+++ b/docs/classes/components.nf-range-marker.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-range-markers.html
+++ b/docs/classes/components.nf-range-markers.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-right-tick.html
+++ b/docs/classes/components.nf-right-tick.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-selection-box.html
+++ b/docs/classes/components.nf-selection-box.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-svg-image.html
+++ b/docs/classes/components.nf-svg-image.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-svg-line.html
+++ b/docs/classes/components.nf-svg-line.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-svg-path.html
+++ b/docs/classes/components.nf-svg-path.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-svg-rect.html
+++ b/docs/classes/components.nf-svg-rect.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-tracker.html
+++ b/docs/classes/components.nf-tracker.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>components.nf-y-diff - ember-nf-graph</title>
+    <title>components.nf-tracker - ember-nf-graph</title>
     <link rel="stylesheet" href="http://yui.yahooapis.com/3.9.1/build/cssgrids/cssgrids-min.css">
     <link rel="stylesheet" href="../assets/vendor/prettify/prettify-min.css">
     <link rel="stylesheet" href="../assets/css/main.css" id="site_styles">
@@ -114,22 +114,20 @@
             <div class="apidocs">
                 <div id="docs-main">
                     <div class="content">
-<h1>components.nf-y-diff Class</h1>
+<h1>components.nf-tracker Class</h1>
 <div class="box meta">
         <div class="uses">
             Uses
             <ul class="inline commas">
                     <li><a href="mixins.graph-has-graph-parent.html">mixins.graph-has-graph-parent</a></li>
+                    <li><a href="mixins.graph-data-graphic.html">mixins.graph-data-graphic</a></li>
                     <li><a href="mixins.graph-requires-scale-source.html">mixins.graph-requires-scale-source</a></li>
             </ul>
         </div>
 
-        <div class="extends">
-            Extends Ember.Component
-        </div>
 
         <div class="foundat">
-            Defined in: <a href="../files/app_components_nf-y-diff.js.html#l6"><code>app&#x2F;components&#x2F;nf-y-diff.js:6</code></a>
+            Defined in: <a href="../files/app_components_nf-tracker.js.html#l11"><code>app&#x2F;components&#x2F;nf-tracker.js:11</code></a>
         </div>
 
             Module: <a href="../modules/utils_nf_svg-dom.html">utils/nf/svg-dom</a>
@@ -138,15 +136,7 @@
 
 
 <div class="box intro">
-    <p>Draws a box underneath (or over) the y axis to between the given <code>a</code> and <code>b</code>
-domain values. Component content is used to template a label in that box.</p>
-<h2>Tips</h2>
-<ul>
-<li>Should be outside of <code>nf-graph-content</code>.</li>
-<li>Should be &quot;above&quot; <code>nf-y-axis</code> in the markup.</li>
-<li>As a convenience, <code>&lt;text&gt;</code> elements will automatically be positioned based on y-axis orientation
-due to default styling.</li>
-</ul>
+    <p>A tracking graphic component used to do things like create tracking dots for nf-area or nf-line.</p>
 
 </div>
 
@@ -166,29 +156,33 @@ due to default styling.</li>
                 <div class="index-section methods">
                     <h3>Methods</h3>
 
-                    <ul class="index-list methods extends">
-                            <li class="index-item method">
-                                <a href="#method_adjustWidth">adjustWidth</a>
+                    <ul class="index-list methods">
+                            <li class="index-item method private">
+                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+
+                            </li>
+                            <li class="index-item method private">
+                                <a href="#method__sendWillTrack">_sendWillTrack</a>
+
+                            </li>
+                            <li class="index-item method private">
+                                <a href="#method_didContentHoverChange">didContentHoverChange</a>
+
+                            </li>
+                            <li class="index-item method private">
+                                <a href="#method_didContentHoverEnd">didContentHoverEnd</a>
 
                             </li>
                             <li class="index-item method">
-                                <a href="#method_didInsertElement">didInsertElement</a>
+                                <a href="#method_didHoverChange">didHoverChange</a>
 
                             </li>
                             <li class="index-item method">
-                                <a href="#method_doAdjustWidth">doAdjustWidth</a>
-
-                            </li>
-                            <li class="index-item method">
-                                <a href="#method_doTransition">doTransition</a>
+                                <a href="#method_didHoverEnd">didHoverEnd</a>
 
                             </li>
                             <li class="index-item method inherited">
                                 <a href="#method_init">init</a>
-
-                            </li>
-                            <li class="index-item method">
-                                <a href="#method_transition">transition</a>
 
                             </li>
                     </ul>
@@ -197,33 +191,17 @@ due to default styling.</li>
                 <div class="index-section properties">
                     <h3>Properties</h3>
 
-                    <ul class="index-list properties extends">
-                            <li class="index-item property">
-                                <a href="#property_a">a</a>
+                    <ul class="index-list properties">
+                            <li class="index-item property inherited">
+                                <a href="#property_data">data</a>
 
                             </li>
                             <li class="index-item property">
-                                <a href="#property_b">b</a>
+                                <a href="#property_didTrack">didTrack</a>
 
                             </li>
-                            <li class="index-item property">
-                                <a href="#property_contentPadding">contentPadding</a>
-
-                            </li>
-                            <li class="index-item property private">
-                                <a href="#property_contentTransform">contentTransform</a>
-
-                            </li>
-                            <li class="index-item property">
-                                <a href="#property_contentX">contentX</a>
-
-                            </li>
-                            <li class="index-item property">
-                                <a href="#property_diff">diff</a>
-
-                            </li>
-                            <li class="index-item property">
-                                <a href="#property_duration">duration</a>
+                            <li class="index-item property inherited">
+                                <a href="#property_firstSortedData">firstSortedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -231,15 +209,19 @@ due to default styling.</li>
 
                             </li>
                             <li class="index-item property">
-                                <a href="#property_isOrientRight">isOrientRight</a>
+                                <a href="#property_hoverChange">hoverChange</a>
 
                             </li>
                             <li class="index-item property">
-                                <a href="#property_isPositive">isPositive</a>
+                                <a href="#property_hoverEnd">hoverEnd</a>
 
                             </li>
-                            <li class="index-item property private">
-                                <a href="#property_parentController">parentController</a>
+                            <li class="index-item property inherited">
+                                <a href="#property_lastVisibleData">lastVisibleData</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_renderedData">renderedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -258,28 +240,32 @@ due to default styling.</li>
                                 <a href="#property_scaleZoomY">scaleZoomY</a>
 
                             </li>
-                            <li class="index-item property private">
-                                <a href="#property_transform">transform</a>
+                            <li class="index-item property">
+                                <a href="#property_trackingMode">trackingMode</a>
 
                             </li>
                             <li class="index-item property">
-                                <a href="#property_width">width</a>
+                                <a href="#property_willTrack">willTrack</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_xprop">xprop</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_xPropFn">xPropFn</a>
 
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_xScale">xScale</a>
 
                             </li>
-                            <li class="index-item property">
-                                <a href="#property_yA">yA</a>
+                            <li class="index-item property inherited">
+                                <a href="#property_yprop">yprop</a>
 
                             </li>
-                            <li class="index-item property">
-                                <a href="#property_yB">yB</a>
-
-                            </li>
-                            <li class="index-item property">
-                                <a href="#property_yCenter">yCenter</a>
+                            <li class="index-item property inherited">
+                                <a href="#property_yPropFn">yPropFn</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -295,13 +281,14 @@ due to default styling.</li>
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method_adjustWidth" class="method item">
-    <h3 class="name"><code>adjustWidth</code></h3>
+<div id="method__sendDidTrack" class="method item private">
+    <h3 class="name"><code>_sendDidTrack</code></h3>
 
         <span class="paren">()</span>
 
 
 
+        <span class="flag private">private</span>
 
 
 
@@ -310,7 +297,7 @@ due to default styling.</li>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-y-diff.js.html#l254"><code>app&#x2F;components&#x2F;nf-y-diff.js:254</code></a>
+        <a href="../files/app_components_nf-tracker.js.html#l206"><code>app&#x2F;components&#x2F;nf-tracker.js:206</code></a>
         </p>
 
 
@@ -318,7 +305,8 @@ due to default styling.</li>
     </div>
 
     <div class="description">
-        <p>Schedules a call to <code>doAdjustWidth</code> on afterRender</p>
+        <p>Observes changes to tracked data and sends the
+didTrack action.</p>
 
     </div>
 
@@ -326,13 +314,14 @@ due to default styling.</li>
 
 
 </div>
-<div id="method_didInsertElement" class="method item">
-    <h3 class="name"><code>didInsertElement</code></h3>
+<div id="method__sendWillTrack" class="method item private">
+    <h3 class="name"><code>_sendWillTrack</code></h3>
 
         <span class="paren">()</span>
 
 
 
+        <span class="flag private">private</span>
 
 
 
@@ -341,7 +330,7 @@ due to default styling.</li>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-y-diff.js.html#l178"><code>app&#x2F;components&#x2F;nf-y-diff.js:178</code></a>
+        <a href="../files/app_components_nf-tracker.js.html#l238"><code>app&#x2F;components&#x2F;nf-tracker.js:238</code></a>
         </p>
 
 
@@ -349,8 +338,8 @@ due to default styling.</li>
     </div>
 
     <div class="description">
-        <p>Sets up the d3 related elements when component is inserted
-into the DOM</p>
+        <p>Observes impending changes to trackedData and sends
+the willTrack action.</p>
 
     </div>
 
@@ -358,13 +347,20 @@ into the DOM</p>
 
 
 </div>
-<div id="method_doAdjustWidth" class="method item">
-    <h3 class="name"><code>doAdjustWidth</code></h3>
+<div id="method_didContentHoverChange" class="method item private">
+    <h3 class="name"><code>didContentHoverChange</code></h3>
 
-        <span class="paren">()</span>
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>e</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
 
 
 
+        <span class="flag private">private</span>
 
 
 
@@ -373,7 +369,7 @@ into the DOM</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-y-diff.js.html#l228"><code>app&#x2F;components&#x2F;nf-y-diff.js:228</code></a>
+        <a href="../files/app_components_nf-tracker.js.html#l130"><code>app&#x2F;components&#x2F;nf-tracker.js:130</code></a>
         </p>
 
 
@@ -381,19 +377,94 @@ into the DOM</p>
     </div>
 
     <div class="description">
-        <p>Updates to d3 managed DOM elments that do
-not require transitioning, because they're width-related.</p>
+        <p>Event handler for content hoverChange event. Triggers <code>didHoverChange</code>.</p>
 
     </div>
 
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">e</code>
+                        <span class="type"><a href="../classes/utils.nf.graph-mouse-event.html" class="crosslink">utils.nf.graph-mouse-event</a></span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+            </ul>
+        </div>
 
 
 
 </div>
-<div id="method_doTransition" class="method item">
-    <h3 class="name"><code>doTransition</code></h3>
+<div id="method_didContentHoverEnd" class="method item private">
+    <h3 class="name"><code>didContentHoverEnd</code></h3>
 
-        <span class="paren">()</span>
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>e</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+
+
+        <span class="flag private">private</span>
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/app_components_nf-tracker.js.html#l256"><code>app&#x2F;components&#x2F;nf-tracker.js:256</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Handles the graph-content's hoverEnd event and triggers didHoverEnd</p>
+
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">e</code>
+                        <span class="type">utils.nf.graph-mouse-action-context</span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+
+
+</div>
+<div id="method_didHoverChange" class="method item">
+    <h3 class="name"><code>didHoverChange</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>e</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
 
 
 
@@ -405,7 +476,7 @@ not require transitioning, because they're width-related.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/app_components_nf-y-diff.js.html#l200"><code>app&#x2F;components&#x2F;nf-y-diff.js:200</code></a>
+        <a href="../files/app_components_nf-tracker.js.html#l146"><code>app&#x2F;components&#x2F;nf-tracker.js:146</code></a>
         </p>
 
 
@@ -413,10 +484,80 @@ not require transitioning, because they're width-related.</p>
     </div>
 
     <div class="description">
-        <p>Performs the transition (animation) of the elements.</p>
+        <p>Event handler for didHoverChange. Sends hoverChange action.</p>
 
     </div>
 
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">e</code>
+                        <span class="type"><a href="../classes/utils.nf.graph-mouse-event.html" class="crosslink">utils.nf.graph-mouse-event</a></span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+
+
+</div>
+<div id="method_didHoverEnd" class="method item">
+    <h3 class="name"><code>didHoverEnd</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>e</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/app_components_nf-tracker.js.html#l177"><code>app&#x2F;components&#x2F;nf-tracker.js:177</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Event handler for didHoverEnd. Updates tracked data, and sends hoverEnd action.</p>
+
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">e</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                        <p>hover end event object.</p>
+
+                    </div>
+
+                </li>
+            </ul>
+        </div>
 
 
 
@@ -454,61 +595,30 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
 
 
 </div>
-<div id="method_transition" class="method item">
-    <h3 class="name"><code>transition</code></h3>
-
-        <span class="paren">()</span>
-
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/app_components_nf-y-diff.js.html#l220"><code>app&#x2F;components&#x2F;nf-y-diff.js:220</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>Schedules a transition once at afterRender.</p>
-
-    </div>
-
-
-
-
-</div>
             </div>
 
             <div id="properties" class="api-class-tabpanel">
                 <h2 class="off-left">Properties</h2>
 
-                    <div id="property_a" class="property item">
-                        <h3 class="name"><code>a</code></h3>
-                        <span class="type">Number</span>
+                    <div id="property_data" class="property item inherited">
+                        <h3 class="name"><code>data</code></h3>
+                        <span class="type">Array</span>
                     
                     
                     
                     
                     
                         <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l30"><code>app&#x2F;components&#x2F;nf-y-diff.js:30</code></a>
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-data-graphic.html#property_data">mixins.graph-data-graphic</a>:
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l25"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:25</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>The starting domain value of the difference measurement. The subrahend of the difference calculation.</p>
+                            <p>&lt;p&gt;Gets or sets the data used by the component to plot itself.&lt;/p&gt;</p>
                     
                         </div>
                     
@@ -516,157 +626,55 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                     
                     
                     </div>
-                    <div id="property_b" class="property item">
-                        <h3 class="name"><code>b</code></h3>
-                        <span class="type">Number</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l38"><code>app&#x2F;components&#x2F;nf-y-diff.js:38</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>The ending domain value of the difference measurement. The minuend of the difference calculation.</p>
-                    
-                        </div>
-                    
-                            <p><strong>Default:</strong> null</p>
-                    
-                    
-                    </div>
-                    <div id="property_contentPadding" class="property item">
-                        <h3 class="name"><code>contentPadding</code></h3>
-                        <span class="type">Number</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l46"><code>app&#x2F;components&#x2F;nf-y-diff.js:46</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>The amount of padding, in pixels, between the edge of the difference &quot;box&quot; and the content container</p>
-                    
-                        </div>
-                    
-                            <p><strong>Default:</strong> 5</p>
-                    
-                    
-                    </div>
-                    <div id="property_contentTransform" class="property item private">
-                        <h3 class="name"><code>contentTransform</code></h3>
+                    <div id="property_didTrack" class="property item">
+                        <h3 class="name"><code>didTrack</code></h3>
                         <span class="type">String</span>
                     
                     
-                            <span class="flag private">private</span>
                     
                     
                     
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l165"><code>app&#x2F;components&#x2F;nf-y-diff.js:165</code></a>
+                            <a href="../files/app_components_nf-tracker.js.html#l198"><code>app&#x2F;components&#x2F;nf-tracker.js:198</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>The SVG transformation used to position the content container.</p>
+                            <p>The action to send on <code>didTrack</code>.</p>
                     
                         </div>
                     
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>
-                    <div id="property_contentX" class="property item">
-                        <h3 class="name"><code>contentX</code></h3>
-                        <span class="type">Number</span>
+                    <div id="property_firstSortedData" class="property item inherited">
+                        <h3 class="name"><code>firstSortedData</code></h3>
+                        <span class="type">Array</span>
                     
                     
                     
                     
                     
                         <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l144"><code>app&#x2F;components&#x2F;nf-y-diff.js:144</code></a>
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-data-graphic.html#property_firstSortedData">mixins.graph-data-graphic</a>:
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l152"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:152</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>The x pixel coordinate of the content container.</p>
+                            <p>&lt;p&gt;The first element from &lt;a href=&quot;../classes/mixins.graph-data-graphic.html#property_renderedData&quot; class=&quot;crosslink&quot;&gt;renderedData&lt;/a&gt;
+                    that is actually visible within the x domain.&lt;/p&gt;</p>
                     
                         </div>
                     
-                    
-                    
-                    </div>
-                    <div id="property_diff" class="property item">
-                        <h3 class="name"><code>diff</code></h3>
-                        <span class="type">Number</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l101"><code>app&#x2F;components&#x2F;nf-y-diff.js:101</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>The calculated difference between <code>a</code> and <code>b</code>.</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
-                    <div id="property_duration" class="property item">
-                        <h3 class="name"><code>duration</code></h3>
-                        <span class="type">Number</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l54"><code>app&#x2F;components&#x2F;nf-y-diff.js:54</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>The duration of the transition, in milliseconds, as the difference slides vertically</p>
-                    
-                        </div>
-                    
-                            <p><strong>Default:</strong> 400</p>
                     
                     
                     </div>
@@ -696,9 +704,9 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                     
                     
                     </div>
-                    <div id="property_isOrientRight" class="property item">
-                        <h3 class="name"><code>isOrientRight</code></h3>
-                        <span class="type">Boolean</span>
+                    <div id="property_hoverChange" class="property item">
+                        <h3 class="name"><code>hoverChange</code></h3>
+                        <span class="type">String</span>
                     
                     
                     
@@ -707,65 +715,93 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l119"><code>app&#x2F;components&#x2F;nf-y-diff.js:119</code></a>
+                            <a href="../files/app_components_nf-tracker.js.html#l122"><code>app&#x2F;components&#x2F;nf-tracker.js:122</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>Returns <code>true</code> if the graph's y-axis component is configured to orient right.</p>
+                            <p>The action name to send to the controller when the <code>hoverChange</code> event fires</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
+                    <div id="property_hoverEnd" class="property item">
+                        <h3 class="name"><code>hoverEnd</code></h3>
+                        <span class="type">String</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>
+                                    Defined in
+                            <a href="../files/app_components_nf-tracker.js.html#l169"><code>app&#x2F;components&#x2F;nf-tracker.js:169</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>Name of the action to send on <code>hoverEnd</code></p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
+                    <div id="property_lastVisibleData" class="property item inherited">
+                        <h3 class="name"><code>lastVisibleData</code></h3>
+                        <span class="type">Array</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-data-graphic.html#property_lastVisibleData">mixins.graph-data-graphic</a>:
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l176"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:176</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>&lt;p&gt;The last element from &lt;a href=&quot;../classes/mixins.graph-data-graphic.html#property_renderedData&quot; class=&quot;crosslink&quot;&gt;renderedData&lt;/a&gt;
+                    that is actually visible within the x domain.&lt;/p&gt;</p>
                     
                         </div>
                     
                     
                     
                     </div>
-                    <div id="property_isPositive" class="property item">
-                        <h3 class="name"><code>isPositive</code></h3>
-                        <span class="type">Boolean</span>
+                    <div id="property_renderedData" class="property item inherited">
+                        <h3 class="name"><code>renderedData</code></h3>
+                        <span class="type">Array</span>
                     
                     
                     
                     
                     
                         <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l111"><code>app&#x2F;components&#x2F;nf-y-diff.js:111</code></a>
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-data-graphic.html#property_renderedData">mixins.graph-data-graphic</a>:
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l111"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:111</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>Returns <code>true</code> if <code>diff</code> is a positive number</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
-                    <div id="property_parentController" class="property item private">
-                        <h3 class="name"><code>parentController</code></h3>
-                        <span class="type">Ember.Controller</span>
-                    
-                    
-                            <span class="flag private">private</span>
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l135"><code>app&#x2F;components&#x2F;nf-y-diff.js:135</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>The view controller for the view this component is present in</p>
+                            <p>&lt;p&gt;The list of data points from mixins.graph-data-graphc/mappedData:property that
+                    fits within the x domain, plus up to one data point outside of that domain in each direction.&lt;/p&gt;</p>
                     
                         </div>
                     
@@ -876,35 +912,47 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                     
                     
                     </div>
-                    <div id="property_transform" class="property item private">
-                        <h3 class="name"><code>transform</code></h3>
+                    <div id="property_trackingMode" class="property item">
+                        <h3 class="name"><code>trackingMode</code></h3>
                         <span class="type">String</span>
                     
                     
-                            <span class="flag private">private</span>
                     
                     
                     
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l92"><code>app&#x2F;components&#x2F;nf-y-diff.js:92</code></a>
+                            <a href="../files/app_components_nf-tracker.js.html#l26"><code>app&#x2F;components&#x2F;nf-tracker.js:26</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>The SVG transformation of the component.</p>
+                            <p>Gets or sets the tracking mode of the component.</p>
+                    <p>Possible values are:</p>
+                    <ul>
+                    <li>'hover': only track while mouse hover</li>
+                    <li>'snap-last': track while mouse hover, but snap to the last data element when not hovering</li>
+                    <li>'snap-first': track while mouse hover, but snap to the first data element when not hovering</li>
+                    <li>'selected-hover': The same as <code>'hover'</code> tracking mode, but only when the compononent is
+                    <a href="../classes/mixins.graph-selectable-graphic.html#property_selected" class="crosslink">selected</a></li>
+                    <li>'selected-snap-last': The same as <code>'snap-last'</code> tracking mode, but only when the compononent is
+                    <a href="../classes/mixins.graph-selectable-graphic.html#property_selected" class="crosslink">selected</a></li>
+                    <li>'selected-snap-first': The same as <code>'snap-first'</code> tracking mode, but only when the compononent is
+                    <a href="../classes/mixins.graph-selectable-graphic.html#property_selected" class="crosslink">selected</a></li>
+                    </ul>
                     
                         </div>
                     
+                            <p><strong>Default:</strong> &#x27;hover&#x27;</p>
                     
                     
                     </div>
-                    <div id="property_width" class="property item">
-                        <h3 class="name"><code>width</code></h3>
-                        <span class="type">Number</span>
+                    <div id="property_willTrack" class="property item">
+                        <h3 class="name"><code>willTrack</code></h3>
+                        <span class="type">String</span>
                     
                     
                     
@@ -913,14 +961,69 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l127"><code>app&#x2F;components&#x2F;nf-y-diff.js:127</code></a>
+                            <a href="../files/app_components_nf-tracker.js.html#l224"><code>app&#x2F;components&#x2F;nf-tracker.js:224</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>The width of the difference box</p>
+                            <p>The action to send on <code>willTrack</code></p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
+                    <div id="property_xprop" class="property item inherited">
+                        <h3 class="name"><code>xprop</code></h3>
+                        <span class="type">String</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-data-graphic.html#property_xprop">mixins.graph-data-graphic</a>:
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l59"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:59</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>&lt;p&gt;The path of the property on each object in
+                    &lt;a href=&quot;../classes/mixins.graph-data-graphic.html#property_data&quot; class=&quot;crosslink&quot;&gt;data&lt;/a&gt;
+                    to use as x data to plot on the graph.&lt;/p&gt;</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> &#x27;x&#x27;</p>
+                    
+                    
+                    </div>
+                    <div id="property_xPropFn" class="property item inherited">
+                        <h3 class="name"><code>xPropFn</code></h3>
+                        <span class="type">Function</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-data-graphic.html#property_xPropFn">mixins.graph-data-graphic</a>:
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l81"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:81</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>&lt;p&gt;The function to get the x value from each
+                    &lt;a href=&quot;../classes/mixins.graph-data-graphic.html#property_data&quot; class=&quot;crosslink&quot;&gt;data&lt;/a&gt; object&lt;/p&gt;</p>
                     
                         </div>
                     
@@ -952,75 +1055,54 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                     
                     
                     </div>
-                    <div id="property_yA" class="property item">
-                        <h3 class="name"><code>yA</code></h3>
-                        <span class="type">Number</span>
+                    <div id="property_yprop" class="property item inherited">
+                        <h3 class="name"><code>yprop</code></h3>
+                        <span class="type">String</span>
                     
                     
                     
                     
                     
                         <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l83"><code>app&#x2F;components&#x2F;nf-y-diff.js:83</code></a>
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-data-graphic.html#property_yprop">mixins.graph-data-graphic</a>:
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l70"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:70</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>The y pixel value of a.</p>
+                            <p>&lt;p&gt;The path of the property on each object in
+                    &lt;a href=&quot;../classes/mixins.graph-data-graphic.html#property_data&quot; class=&quot;crosslink&quot;&gt;data&lt;/a&gt;
+                    to use as y data to plot on the graph.&lt;/p&gt;</p>
                     
                         </div>
                     
+                            <p><strong>Default:</strong> &#x27;y&#x27;</p>
                     
                     
                     </div>
-                    <div id="property_yB" class="property item">
-                        <h3 class="name"><code>yB</code></h3>
-                        <span class="type">Number</span>
+                    <div id="property_yPropFn" class="property item inherited">
+                        <h3 class="name"><code>yPropFn</code></h3>
+                        <span class="type">Function</span>
                     
                     
                     
                     
                     
                         <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l74"><code>app&#x2F;components&#x2F;nf-y-diff.js:74</code></a>
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-data-graphic.html#property_yPropFn">mixins.graph-data-graphic</a>:
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l96"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:96</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>The y pixel value of b.</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
-                    <div id="property_yCenter" class="property item">
-                        <h3 class="name"><code>yCenter</code></h3>
-                        <span class="type">Number</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/app_components_nf-y-diff.js.html#l62"><code>app&#x2F;components&#x2F;nf-y-diff.js:62</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>The calculated vertical center of the difference box, in pixels.</p>
+                            <p>&lt;p&gt;The function to get the y value from each
+                    &lt;a href=&quot;../classes/mixins.graph-data-graphic.html#property_data&quot; class=&quot;crosslink&quot;&gt;data&lt;/a&gt; object&lt;/p&gt;</p>
                     
                         </div>
                     

--- a/docs/classes/components.nf-vertical-line.html
+++ b/docs/classes/components.nf-vertical-line.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/components.nf-x-axis.html
+++ b/docs/classes/components.nf-x-axis.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -150,7 +151,7 @@ templating, along with the tick line. <code>&lt;text&gt;</code> tags within tick
 default styling applied to them to position them appropriately based off of orientation.</p>
 <h3>Example</h3>
 <pre class="code prettyprint"><code>  {{#nf-graph width=500 height=300}}
-    {{#nf-x-axis height=40}}
+    {{#nf-x-axis height=40 as |tick|}}
       &lt;text&gt;x is {{tick.value}}&lt;/text&gt;
     {{/nf-x-axis}}
   {{/nf-graph}}</code></pre>
@@ -331,7 +332,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l285"><code>app&#x2F;components&#x2F;nf-x-axis.js:285</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l282"><code>app&#x2F;components&#x2F;nf-x-axis.js:282</code></a>
                             </p>
                     
                     
@@ -382,7 +383,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l50"><code>app&#x2F;components&#x2F;nf-x-axis.js:50</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l48"><code>app&#x2F;components&#x2F;nf-x-axis.js:48</code></a>
                             </p>
                     
                     
@@ -408,7 +409,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l83"><code>app&#x2F;components&#x2F;nf-x-axis.js:83</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l81"><code>app&#x2F;components&#x2F;nf-x-axis.js:81</code></a>
                             </p>
                     
                     
@@ -434,7 +435,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l117"><code>app&#x2F;components&#x2F;nf-x-axis.js:117</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l115"><code>app&#x2F;components&#x2F;nf-x-axis.js:115</code></a>
                             </p>
                     
                     
@@ -563,7 +564,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l58"><code>app&#x2F;components&#x2F;nf-x-axis.js:58</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l56"><code>app&#x2F;components&#x2F;nf-x-axis.js:56</code></a>
                             </p>
                     
                     
@@ -589,7 +590,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l193"><code>app&#x2F;components&#x2F;nf-x-axis.js:193</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l190"><code>app&#x2F;components&#x2F;nf-x-axis.js:190</code></a>
                             </p>
                     
                     
@@ -624,7 +625,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l93"><code>app&#x2F;components&#x2F;nf-x-axis.js:93</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l91"><code>app&#x2F;components&#x2F;nf-x-axis.js:91</code></a>
                             </p>
                     
                     
@@ -643,7 +644,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                                 <h4>Example:</h4>
                     
                                 <div class="example-content">
-                                    <pre class="code prettyprint"><code>  {{#nf-x-axis tickFilter=myFilter}}
+                                    <pre class="code prettyprint"><code>  {{#nf-x-axis tickFilter=myFilter as |tick|}}
                         &lt;text&gt;{{tick.value}}&lt;/text&gt;
                       {{/nf-x-axis}}
                     </code></pre>
@@ -669,7 +670,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l66"><code>app&#x2F;components&#x2F;nf-x-axis.js:66</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l64"><code>app&#x2F;components&#x2F;nf-x-axis.js:64</code></a>
                             </p>
                     
                     
@@ -695,7 +696,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l74"><code>app&#x2F;components&#x2F;nf-x-axis.js:74</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l72"><code>app&#x2F;components&#x2F;nf-x-axis.js:72</code></a>
                             </p>
                     
                     
@@ -722,7 +723,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l239"><code>app&#x2F;components&#x2F;nf-x-axis.js:239</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l236"><code>app&#x2F;components&#x2F;nf-x-axis.js:236</code></a>
                             </p>
                     
                     
@@ -747,7 +748,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l127"><code>app&#x2F;components&#x2F;nf-x-axis.js:127</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l125"><code>app&#x2F;components&#x2F;nf-x-axis.js:125</code></a>
                             </p>
                     
                     
@@ -772,7 +773,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l231"><code>app&#x2F;components&#x2F;nf-x-axis.js:231</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l228"><code>app&#x2F;components&#x2F;nf-x-axis.js:228</code></a>
                             </p>
                     
                     
@@ -797,7 +798,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l185"><code>app&#x2F;components&#x2F;nf-x-axis.js:185</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l182"><code>app&#x2F;components&#x2F;nf-x-axis.js:182</code></a>
                             </p>
                     
                     
@@ -822,7 +823,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l169"><code>app&#x2F;components&#x2F;nf-x-axis.js:169</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l167"><code>app&#x2F;components&#x2F;nf-x-axis.js:167</code></a>
                             </p>
                     
                     
@@ -872,7 +873,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-x-axis.js.html#l139"><code>app&#x2F;components&#x2F;nf-x-axis.js:139</code></a>
+                            <a href="../files/app_components_nf-x-axis.js.html#l137"><code>app&#x2F;components&#x2F;nf-x-axis.js:137</code></a>
                             </p>
                     
                     

--- a/docs/classes/components.nf-y-axis.html
+++ b/docs/classes/components.nf-y-axis.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -147,7 +148,7 @@ templating, along with the tick line. <code>&lt;text&gt;</code> tags within tick
 default styling applied to them to position them appropriately based off of orientation.</p>
 <h3>Example</h3>
 <pre class="code prettyprint"><code>  {{#nf-graph width=500 height=300}}
-    {{#nf-y-axis width=40}}
+    {{#nf-y-axis width=40 as |tick|}}
       &lt;text&gt;y is {{tick.value}}&lt;/text&gt;
     {{/nf-y-axis}}
   {{/nf-graph}}</code></pre>
@@ -328,7 +329,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l281"><code>app&#x2F;components&#x2F;nf-y-axis.js:281</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l278"><code>app&#x2F;components&#x2F;nf-y-axis.js:278</code></a>
                             </p>
                     
                     
@@ -379,7 +380,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l170"><code>app&#x2F;components&#x2F;nf-y-axis.js:170</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l168"><code>app&#x2F;components&#x2F;nf-y-axis.js:168</code></a>
                             </p>
                     
                     
@@ -404,7 +405,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l120"><code>app&#x2F;components&#x2F;nf-y-axis.js:120</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l118"><code>app&#x2F;components&#x2F;nf-y-axis.js:118</code></a>
                             </p>
                     
                     
@@ -429,7 +430,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l77"><code>app&#x2F;components&#x2F;nf-y-axis.js:77</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l75"><code>app&#x2F;components&#x2F;nf-y-axis.js:75</code></a>
                             </p>
                     
                     
@@ -559,7 +560,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l45"><code>app&#x2F;components&#x2F;nf-y-axis.js:45</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l43"><code>app&#x2F;components&#x2F;nf-y-axis.js:43</code></a>
                             </p>
                     
                     
@@ -585,7 +586,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l184"><code>app&#x2F;components&#x2F;nf-y-axis.js:184</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l181"><code>app&#x2F;components&#x2F;nf-y-axis.js:181</code></a>
                             </p>
                     
                     
@@ -620,7 +621,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l91"><code>app&#x2F;components&#x2F;nf-y-axis.js:91</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l89"><code>app&#x2F;components&#x2F;nf-y-axis.js:89</code></a>
                             </p>
                     
                     
@@ -639,7 +640,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                                 <h4>Example:</h4>
                     
                                 <div class="example-content">
-                                    <pre class="code prettyprint"><code>  {{#nf-y-axis tickFilter=myFilter}} 
+                                    <pre class="code prettyprint"><code>  {{#nf-y-axis tickFilter=myFilter as |tick|}}
                         &lt;text&gt;{{tick.value}}&lt;/text&gt;
                       {{/nf-y-axis}}
                     </code></pre>
@@ -665,7 +666,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l53"><code>app&#x2F;components&#x2F;nf-y-axis.js:53</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l51"><code>app&#x2F;components&#x2F;nf-y-axis.js:51</code></a>
                             </p>
                     
                     
@@ -691,7 +692,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l61"><code>app&#x2F;components&#x2F;nf-y-axis.js:61</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l59"><code>app&#x2F;components&#x2F;nf-y-axis.js:59</code></a>
                             </p>
                     
                     
@@ -717,7 +718,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l237"><code>app&#x2F;components&#x2F;nf-y-axis.js:237</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l234"><code>app&#x2F;components&#x2F;nf-y-axis.js:234</code></a>
                             </p>
                     
                     
@@ -742,7 +743,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l129"><code>app&#x2F;components&#x2F;nf-y-axis.js:129</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l127"><code>app&#x2F;components&#x2F;nf-y-axis.js:127</code></a>
                             </p>
                     
                     
@@ -767,7 +768,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l229"><code>app&#x2F;components&#x2F;nf-y-axis.js:229</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l226"><code>app&#x2F;components&#x2F;nf-y-axis.js:226</code></a>
                             </p>
                     
                     
@@ -792,7 +793,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l69"><code>app&#x2F;components&#x2F;nf-y-axis.js:69</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l67"><code>app&#x2F;components&#x2F;nf-y-axis.js:67</code></a>
                             </p>
                     
                     
@@ -818,7 +819,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l141"><code>app&#x2F;components&#x2F;nf-y-axis.js:141</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l139"><code>app&#x2F;components&#x2F;nf-y-axis.js:139</code></a>
                             </p>
                     
                     
@@ -868,7 +869,7 @@ NOTE: all object that mixin and have init, must call super.init()&lt;/p&gt;</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/app_components_nf-y-axis.js.html#l162"><code>app&#x2F;components&#x2F;nf-y-axis.js:162</code></a>
+                            <a href="../files/app_components_nf-y-axis.js.html#l160"><code>app&#x2F;components&#x2F;nf-y-axis.js:160</code></a>
                             </p>
                     
                     

--- a/docs/classes/mixins.graph-area-utils.html
+++ b/docs/classes/mixins.graph-area-utils.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/mixins.graph-data-graphic.html
+++ b/docs/classes/mixins.graph-data-graphic.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -121,7 +122,7 @@
         </div>
 
         <div class="foundat">
-            Defined in: <a href="../files/addon_mixins_graph-data-graphic.js.html#l8"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:8</code></a>
+            Defined in: <a href="../files/addon_mixins_graph-data-graphic.js.html#l10"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:10</code></a>
         </div>
 
             Module: <a href="../modules/utils_nf_array-helpers.html">utils/nf/array-helpers</a>
@@ -172,23 +173,11 @@ for use in graphing components.</p>
 
                             </li>
                             <li class="index-item property">
-                                <a href="#property_sortedData">sortedData</a>
-
-                            </li>
-                            <li class="index-item property">
-                                <a href="#property_xData">xData</a>
-
-                            </li>
-                            <li class="index-item property">
                                 <a href="#property_xprop">xprop</a>
 
                             </li>
                             <li class="index-item property">
                                 <a href="#property_xPropFn">xPropFn</a>
-
-                            </li>
-                            <li class="index-item property">
-                                <a href="#property_yData">yData</a>
 
                             </li>
                             <li class="index-item property">
@@ -220,7 +209,7 @@ for use in graphing components.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l23"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:23</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l25"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:25</code></a>
                             </p>
                     
                     
@@ -246,7 +235,7 @@ for use in graphing components.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l195"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:195</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l152"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:152</code></a>
                             </p>
                     
                     
@@ -272,7 +261,7 @@ for use in graphing components.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l219"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:219</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l176"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:176</code></a>
                             </p>
                     
                     
@@ -298,70 +287,15 @@ for use in graphing components.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l154"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:154</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l111"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:111</code></a>
                             </p>
                     
                     
                         </div>
                     
                         <div class="description">
-                            <p>The list of data points from mixins.graph-data-graphc/sortedData:property that
+                            <p>The list of data points from mixins.graph-data-graphc/mappedData:property that
                     fits within the x domain, plus up to one data point outside of that domain in each direction.</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
-                    <div id="property_sortedData" class="property item">
-                        <h3 class="name"><code>sortedData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l100"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:100</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>The sorted and mapped data pulled from <a href="../classes/mixins.graph-data-graphic.html#property_data" class="crosslink">data</a>
-                    An array of arrays, structures as so:</p>
-                    <pre class="code prettyprint"><code>  [[x,y],[x,y],[x,y]];
-                    </code></pre>
-                    <p>** each inner array also has a property <code>data</code> on it, containing the original data object **</p>
-                    <p>When this property is computed, it also updates the <code>xData</code> and <code>yData</code> properties of the graphic.</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
-                    <div id="property_xData" class="property item">
-                        <h3 class="name"><code>xData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l84"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:84</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>Gets the x values from the <code>sortedData</code>.</p>
                     
                         </div>
                     
@@ -379,7 +313,7 @@ for use in graphing components.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l32"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:32</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l59"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:59</code></a>
                             </p>
                     
                     
@@ -407,7 +341,7 @@ for use in graphing components.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l54"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:54</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l81"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:81</code></a>
                             </p>
                     
                     
@@ -416,31 +350,6 @@ for use in graphing components.</p>
                         <div class="description">
                             <p>The function to get the x value from each
                     <a href="../classes/mixins.graph-data-graphic.html#property_data" class="crosslink">data</a> object</p>
-                    
-                        </div>
-                    
-                    
-                    
-                    </div>
-                    <div id="property_yData" class="property item">
-                        <h3 class="name"><code>yData</code></h3>
-                        <span class="type">Array</span>
-                    
-                    
-                    
-                    
-                    
-                        <div class="meta">
-                                    <p>
-                                    Defined in
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l92"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:92</code></a>
-                            </p>
-                    
-                    
-                        </div>
-                    
-                        <div class="description">
-                            <p>Gets the y values from the <code>sortedData</code></p>
                     
                         </div>
                     
@@ -458,7 +367,7 @@ for use in graphing components.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l43"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:43</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l70"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:70</code></a>
                             </p>
                     
                     
@@ -486,7 +395,7 @@ for use in graphing components.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l69"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:69</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l96"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:96</code></a>
                             </p>
                     
                     

--- a/docs/classes/mixins.graph-graphic-with-tracking-dot.html
+++ b/docs/classes/mixins.graph-graphic-with-tracking-dot.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/mixins.graph-has-graph-parent.html
+++ b/docs/classes/mixins.graph-has-graph-parent.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/mixins.graph-line-utils.html
+++ b/docs/classes/mixins.graph-line-utils.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/mixins.graph-registered-graphic.html
+++ b/docs/classes/mixins.graph-registered-graphic.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/mixins.graph-requires-scale-source.html
+++ b/docs/classes/mixins.graph-requires-scale-source.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/mixins.graph-selectable-graphic.html
+++ b/docs/classes/mixins.graph-selectable-graphic.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/utils.nf.graph-event.html
+++ b/docs/classes/utils.nf.graph-event.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/utils.nf.graph-mouse-event.html
+++ b/docs/classes/utils.nf.graph-mouse-event.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/utils.nf.graph-position.html
+++ b/docs/classes/utils.nf.graph-position.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/utils.nf.scroll-area-action-context.html
+++ b/docs/classes/utils.nf.scroll-area-action-context.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/classes/utils.parse-property-expression.html
+++ b/docs/classes/utils.parse-property-expression.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/data.json
+++ b/docs/data.json
@@ -392,6 +392,17 @@
                 "components": 1
             }
         },
+        "app/components/nf-tracker.js": {
+            "name": "app/components/nf-tracker.js",
+            "modules": {},
+            "classes": {
+                "components.nf-tracker": 1
+            },
+            "fors": {},
+            "namespaces": {
+                "components": 1
+            }
+        },
         "app/components/nf-vertical-line.js": {
             "name": "app/components/nf-vertical-line.js",
             "modules": {},
@@ -501,6 +512,7 @@
                 "components.nf-svg-line": 1,
                 "components.nf-svg-path": 1,
                 "components.nf-svg-rect": 1,
+                "components.nf-tracker": 1,
                 "components.nf-vertical-line": 1,
                 "components.nf-x-axis": 1,
                 "components.nf-y-axis": 1,
@@ -544,12 +556,13 @@
             "extension_for": [
                 "components.nf-area",
                 "components.nf-bars",
-                "components.nf-line"
+                "components.nf-line",
+                "components.nf-tracker"
             ],
             "module": "utils/nf/array-helpers",
             "namespace": "mixins",
             "file": "addon/mixins/graph-data-graphic.js",
-            "line": 8,
+            "line": 10,
             "description": "This is mixed in to {{#crossLink components.nf-graph}}nf-graph{{/crossLink}} child components that need to register data\nwith the graph. Includes methods for extracting, sorting and scrubbing data\nfor use in graphing components.\n\nRequires {{#crossLink \"mixins.graph-registered-graphic\"}}{{/crossLink}} and \n{{#crossLink \"mixins.graph-has-graph-parent\"}}{{/crossLink}}",
             "extends": "Ember.Mixin"
         },
@@ -595,6 +608,7 @@
                 "components.nf-svg-line",
                 "components.nf-svg-path",
                 "components.nf-svg-rect",
+                "components.nf-tracker",
                 "components.nf-vertical-line",
                 "components.nf-x-axis",
                 "components.nf-y-axis",
@@ -661,6 +675,7 @@
                 "components.nf-svg-line",
                 "components.nf-svg-path",
                 "components.nf-svg-rect",
+                "components.nf-tracker",
                 "components.nf-vertical-line",
                 "components.nf-x-axis",
                 "components.nf-y-axis",
@@ -912,7 +927,7 @@
             "namespace": "components",
             "file": "app/components/nf-graph.js",
             "line": 221,
-            "description": "A container component for building complex Cartesian graphs.\n\n## Minimal example\n\n     {{#nf-graph width=100 height=50}}\n       {{#nf-graph-content}}\n         {{nf-line data=lineData xprop=\"foo\" yprop=\"bar\"}}\n       {{/nf-graph-content}}\n     {{/nf-graph}}\n\nThe above will create a simple 100x50 graph, with no axes, and a single line\nplotting the data it finds on each object in the array `lineData` at properties\n`foo` and `bar` for x and y values respectively.\n\n## More advanced example\n\n     {{#nf-graph width=500 height=300}}\n       {{#nf-x-axis height=\"50\"}}\n         <text>{{tick.value}}</text>\n       {{/nf-x-axis}}\n \n       {{#nf-y-axis width=\"120\"}}\n         <text>{{tick.value}}</text>\n       {{/nf-y-axis}}\n \n       {{#nf-graph-content}}\n         {{nf-line data=lineData xprop=\"foo\" yprop=\"bar\"}}\n       {{/nf-graph-content}}\n     {{/nf-graph}}\n\nThe above example will create a 500x300 graph with both axes visible. The graph will not \nrender either axis unless its component is present.",
+            "description": "A container component for building complex Cartesian graphs.\n\n## Minimal example\n\n     {{#nf-graph width=100 height=50}}\n       {{#nf-graph-content}}\n         {{nf-line data=lineData xprop=\"foo\" yprop=\"bar\"}}\n       {{/nf-graph-content}}\n     {{/nf-graph}}\n\nThe above will create a simple 100x50 graph, with no axes, and a single line\nplotting the data it finds on each object in the array `lineData` at properties\n`foo` and `bar` for x and y values respectively.\n\n## More advanced example\n\n     {{#nf-graph width=500 height=300}}\n       {{#nf-x-axis height=\"50\" as |tick|}}\n         <text>{{tick.value}}</text>\n       {{/nf-x-axis}}\n\n       {{#nf-y-axis width=\"120\" as |tick|}}\n         <text>{{tick.value}}</text>\n       {{/nf-y-axis}}\n \n       {{#nf-graph-content}}\n         {{nf-line data=lineData xprop=\"foo\" yprop=\"bar\"}}\n       {{/nf-graph-content}}\n     {{/nf-graph}}\n\nThe above example will create a 500x300 graph with both axes visible. The graph will not \nrender either axis unless its component is present.",
             "extends": "Ember.Component"
         },
         "components.nf-horizontal-line": {
@@ -1132,6 +1147,25 @@
                 "mixins.graph-selectable-graphic"
             ]
         },
+        "components.nf-tracker": {
+            "name": "components.nf-tracker",
+            "shortname": "components.nf-tracker",
+            "classitems": [],
+            "plugins": [],
+            "extensions": [],
+            "plugin_for": [],
+            "extension_for": [],
+            "module": "utils/nf/svg-dom",
+            "namespace": "components",
+            "file": "app/components/nf-tracker.js",
+            "line": 11,
+            "description": "A tracking graphic component used to do things like create tracking dots for nf-area or nf-line.",
+            "uses": [
+                "mixins.graph-has-graph-parent",
+                "mixins.graph-data-graphic",
+                "mixins.graph-requires-scale-source"
+            ]
+        },
         "components.nf-vertical-line": {
             "name": "components.nf-vertical-line",
             "shortname": "components.nf-vertical-line",
@@ -1163,7 +1197,7 @@
             "namespace": "components",
             "file": "app/components/nf-x-axis.js",
             "line": 7,
-            "description": "A component for adding a templated x axis to an `nf-graph` component.\nAll items contained within this component are used to template each tick mark on the\nrendered graph. Tick values are supplied to the inner scope of this component on the\nview template via `tick`.\n\n### Styling\n\nThe main container will have a `nf-x-axis` class.\nA `orient-top` or `orient-bottom` container will be applied to the container\ndepending on the `orient` setting.\n\nTicks are positioned via a `<g>` tag, that will contain whatever is passed into it via\ntemplating, along with the tick line. `<text>` tags within tick templates do have some\ndefault styling applied to them to position them appropriately based off of orientation.\n\n### Example\n\n      {{#nf-graph width=500 height=300}}\n        {{#nf-x-axis height=40}}\n          <text>x is {{tick.value}}</text>\n        {{/nf-x-axis}}\n      {{/nf-graph}}",
+            "description": "A component for adding a templated x axis to an `nf-graph` component.\nAll items contained within this component are used to template each tick mark on the\nrendered graph. Tick values are supplied to the inner scope of this component on the\nview template via `tick`.\n\n### Styling\n\nThe main container will have a `nf-x-axis` class.\nA `orient-top` or `orient-bottom` container will be applied to the container\ndepending on the `orient` setting.\n\nTicks are positioned via a `<g>` tag, that will contain whatever is passed into it via\ntemplating, along with the tick line. `<text>` tags within tick templates do have some\ndefault styling applied to them to position them appropriately based off of orientation.\n\n### Example\n\n      {{#nf-graph width=500 height=300}}\n        {{#nf-x-axis height=40 as |tick|}}\n          <text>x is {{tick.value}}</text>\n        {{/nf-x-axis}}\n      {{/nf-graph}}",
             "extends": "Ember.Component",
             "uses": [
                 "mixins.graph-has-graph-parent",
@@ -1182,7 +1216,7 @@
             "namespace": "components",
             "file": "app/components/nf-y-axis.js",
             "line": 7,
-            "description": "A component for adding a templated y axis to an `nf-graph` component.\nAll items contained within this component are used to template each tick mark on the \nrendered graph. Tick values are supplied to the inner scope of this component on the\nview template via `tick`.\n\n### Styling\n\nThe main container will have a `nf-y-axis` class.\nA `orient-left` or `orient-right` container will be applied to the container\ndepending on the `orient` setting.\n\nTicks are positioned via a `<g>` tag, that will contain whatever is passed into it via\ntemplating, along with the tick line. `<text>` tags within tick templates do have some \ndefault styling applied to them to position them appropriately based off of orientation.\n\n### Example\n\n      {{#nf-graph width=500 height=300}}\n        {{#nf-y-axis width=40}}\n          <text>y is {{tick.value}}</text>\n        {{/nf-y-axis}}\n      {{/nf-graph}}",
+            "description": "A component for adding a templated y axis to an `nf-graph` component.\nAll items contained within this component are used to template each tick mark on the \nrendered graph. Tick values are supplied to the inner scope of this component on the\nview template via `tick`.\n\n### Styling\n\nThe main container will have a `nf-y-axis` class.\nA `orient-left` or `orient-right` container will be applied to the container\ndepending on the `orient` setting.\n\nTicks are positioned via a `<g>` tag, that will contain whatever is passed into it via\ntemplating, along with the tick line. `<text>` tags within tick templates do have some \ndefault styling applied to them to position them appropriately based off of orientation.\n\n### Example\n\n      {{#nf-graph width=500 height=300}}\n        {{#nf-y-axis width=40 as |tick|}}\n          <text>y is {{tick.value}}</text>\n        {{/nf-y-axis}}\n      {{/nf-graph}}",
             "uses": [
                 "mixins.graph-has-graph-parent",
                 "mixins.graph-requires-scale-source"
@@ -1241,7 +1275,7 @@
         },
         {
             "file": "addon/mixins/graph-data-graphic.js",
-            "line": 23,
+            "line": 25,
             "description": "Gets or sets the data used by the component to plot itself.",
             "itemtype": "property",
             "name": "data",
@@ -1252,7 +1286,7 @@
         },
         {
             "file": "addon/mixins/graph-data-graphic.js",
-            "line": 32,
+            "line": 59,
             "description": "The path of the property on each object in \n{{#crossLink \"mixins.graph-data-graphic/data:property\"}}{{/crossLink}}\nto use as x data to plot on the graph.",
             "itemtype": "property",
             "name": "xprop",
@@ -1263,7 +1297,7 @@
         },
         {
             "file": "addon/mixins/graph-data-graphic.js",
-            "line": 43,
+            "line": 70,
             "description": "The path of the property on each object in \n{{#crossLink \"mixins.graph-data-graphic/data:property\"}}{{/crossLink}}\nto use as y data to plot on the graph.",
             "itemtype": "property",
             "name": "yprop",
@@ -1274,7 +1308,7 @@
         },
         {
             "file": "addon/mixins/graph-data-graphic.js",
-            "line": 54,
+            "line": 81,
             "description": "The function to get the x value from each \n{{#crossLink \"mixins.graph-data-graphic/data:property\"}}{{/crossLink}} object",
             "itemtype": "property",
             "name": "xPropFn",
@@ -1285,7 +1319,7 @@
         },
         {
             "file": "addon/mixins/graph-data-graphic.js",
-            "line": 69,
+            "line": 96,
             "description": "The function to get the y value from each \n{{#crossLink \"mixins.graph-data-graphic/data:property\"}}{{/crossLink}} object",
             "itemtype": "property",
             "name": "yPropFn",
@@ -1296,41 +1330,8 @@
         },
         {
             "file": "addon/mixins/graph-data-graphic.js",
-            "line": 84,
-            "description": "Gets the x values from the `sortedData`.",
-            "itemtype": "property",
-            "name": "xData",
-            "type": "Array",
-            "readonly": "",
-            "class": "mixins.graph-data-graphic",
-            "namespace": "mixins"
-        },
-        {
-            "file": "addon/mixins/graph-data-graphic.js",
-            "line": 92,
-            "description": "Gets the y values from the `sortedData`",
-            "itemtype": "property",
-            "name": "yData",
-            "type": "Array",
-            "readonly": "",
-            "class": "mixins.graph-data-graphic",
-            "namespace": "mixins"
-        },
-        {
-            "file": "addon/mixins/graph-data-graphic.js",
-            "line": 100,
-            "description": "The sorted and mapped data pulled from {{#crossLink \"mixins.graph-data-graphic/data:property\"}}{{/crossLink}}\nAn array of arrays, structures as so:\n\n      [[x,y],[x,y],[x,y]];\n\n** each inner array also has a property `data` on it, containing the original data object **\n\nWhen this property is computed, it also updates the `xData` and `yData` properties of the graphic.",
-            "itemtype": "property",
-            "name": "sortedData",
-            "type": "Array",
-            "readonly": "",
-            "class": "mixins.graph-data-graphic",
-            "namespace": "mixins"
-        },
-        {
-            "file": "addon/mixins/graph-data-graphic.js",
-            "line": 154,
-            "description": "The list of data points from {{#crossLink \"mixins.graph-data-graphc/sortedData:property\"}}{{/crossLink}} that\nfits within the x domain, plus up to one data point outside of that domain in each direction.",
+            "line": 111,
+            "description": "The list of data points from {{#crossLink \"mixins.graph-data-graphc/mappedData:property\"}}{{/crossLink}} that\nfits within the x domain, plus up to one data point outside of that domain in each direction.",
             "itemtype": "property",
             "name": "renderedData",
             "type": "Array",
@@ -1340,7 +1341,7 @@
         },
         {
             "file": "addon/mixins/graph-data-graphic.js",
-            "line": 195,
+            "line": 152,
             "description": "The first element from {{#crossLink \"mixins.graph-data-graphic/renderedData:property\"}}{{/crossLink}}\nthat is actually visible within the x domain.",
             "itemtype": "property",
             "name": "firstSortedData",
@@ -1351,7 +1352,7 @@
         },
         {
             "file": "addon/mixins/graph-data-graphic.js",
-            "line": 219,
+            "line": 176,
             "description": "The last element from {{#crossLink \"mixins.graph-data-graphic/renderedData:property\"}}{{/crossLink}}\nthat is actually visible within the x domain.",
             "itemtype": "property",
             "name": "lastVisibleData",
@@ -2459,6 +2460,18 @@
         {
             "file": "app/components/nf-area-stack.js",
             "line": 37,
+            "description": "Whether or not to add the values together to create the stacked area",
+            "itemtype": "property",
+            "name": "aggregate",
+            "type": "{boolean}",
+            "default": "false",
+            "class": "components.nf-area-stack",
+            "module": "utils/nf/svg-dom",
+            "namespace": "components"
+        },
+        {
+            "file": "app/components/nf-area-stack.js",
+            "line": 53,
             "description": "The collection of `nf-area` components under this stack.",
             "itemtype": "property",
             "name": "areas",
@@ -2470,7 +2483,7 @@
         },
         {
             "file": "app/components/nf-area-stack.js",
-            "line": 47,
+            "line": 63,
             "description": "Registers an area component with this stack. Also links areas to one\nanother by setting `nextArea` on each area component.",
             "itemtype": "method",
             "name": "registerArea",
@@ -2487,7 +2500,7 @@
         },
         {
             "file": "app/components/nf-area-stack.js",
-            "line": 65,
+            "line": 81,
             "description": "Unregisters an area component from this stack. Also updates next\nand previous links.",
             "itemtype": "method",
             "name": "unregisterArea",
@@ -2552,10 +2565,10 @@
         },
         {
             "file": "app/components/nf-area.js",
-            "line": 96,
+            "line": 90,
             "description": "The current rendered data \"zipped\" together with the nextYData.",
             "itemtype": "property",
-            "name": "areaData",
+            "name": "mappedData",
             "type": "Array",
             "readonly": "",
             "class": "components.nf-area",
@@ -2564,7 +2577,7 @@
         },
         {
             "file": "app/components/nf-area.js",
-            "line": 110,
+            "line": 108,
             "description": "Gets the area function to use to create the area SVG path data",
             "itemtype": "property",
             "name": "areaFn",
@@ -2576,7 +2589,7 @@
         },
         {
             "file": "app/components/nf-area.js",
-            "line": 123,
+            "line": 121,
             "description": "The SVG path data for the area",
             "itemtype": "property",
             "name": "d",
@@ -3364,7 +3377,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 597,
+            "line": 613,
             "description": "Gets the highest and lowest x values of the graphed data in a two element array.",
             "itemtype": "property",
             "name": "xDataExtent",
@@ -3376,7 +3389,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 608,
+            "line": 624,
             "description": "Gets the highest and lowest y values of the graphed data in a two element array.",
             "itemtype": "property",
             "name": "yDataExtent",
@@ -3388,7 +3401,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 619,
+            "line": 635,
             "description": "Gets all x data from all graphics.",
             "itemtype": "property",
             "name": "xData",
@@ -3400,7 +3413,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 634,
+            "line": 650,
             "description": "Gets all y data from all graphics",
             "itemtype": "property",
             "name": "yData",
@@ -3412,7 +3425,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 649,
+            "line": 665,
             "description": "Gets the DOM id for the content clipPath element.",
             "itemtype": "property",
             "name": "contentClipPathId",
@@ -3426,7 +3439,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 660,
+            "line": 676,
             "description": "Registry of contained graphic elements such as `nf-line` or `nf-area` components.\nThis registry is used to pool data for scaling purposes.",
             "itemtype": "property",
             "name": "graphics",
@@ -3438,7 +3451,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 671,
+            "line": 687,
             "description": "An array of \"selectable\" graphics that have been selected within this graph.",
             "itemtype": "property",
             "name": "selected",
@@ -3450,7 +3463,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 679,
+            "line": 695,
             "description": "Computed property to show yAxis. Returns `true` if a yAxis is present.",
             "itemtype": "property",
             "name": "showYAxis",
@@ -3462,7 +3475,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 687,
+            "line": 703,
             "description": "Computed property to show xAxis. Returns `true` if an xAxis is present.",
             "itemtype": "property",
             "name": "showXAxis",
@@ -3474,7 +3487,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 695,
+            "line": 711,
             "description": "Gets a function to create the xScale",
             "itemtype": "property",
             "name": "xScaleFactory",
@@ -3485,7 +3498,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 702,
+            "line": 718,
             "description": "Gets a function to create the yScale",
             "itemtype": "property",
             "name": "yScaleFactory",
@@ -3496,7 +3509,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 709,
+            "line": 725,
             "description": "Gets the domain of x values.",
             "itemtype": "property",
             "name": "xDomain",
@@ -3508,7 +3521,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 717,
+            "line": 733,
             "description": "Gets the domain of y values.",
             "itemtype": "property",
             "name": "yDomain",
@@ -3520,7 +3533,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 725,
+            "line": 741,
             "description": "Gets the current xScale used to draw the graph.",
             "itemtype": "property",
             "name": "xScale",
@@ -3532,7 +3545,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 733,
+            "line": 749,
             "description": "Gets the current yScale used to draw the graph.",
             "itemtype": "property",
             "name": "yScale",
@@ -3544,7 +3557,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 741,
+            "line": 757,
             "description": "Registers a graphic such as `nf-line` or `nf-area` components with the graph.",
             "itemtype": "method",
             "name": "registerGraphic",
@@ -3561,7 +3574,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 751,
+            "line": 768,
             "description": "Unregisters a graphic such as an `nf-line` or `nf-area` from the graph.",
             "itemtype": "method",
             "name": "unregisterGraphic",
@@ -3578,7 +3591,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 761,
+            "line": 784,
             "description": "The y range of the graph in pixels. The min and max pixel values\nin an array form.",
             "itemtype": "property",
             "name": "yRange",
@@ -3590,7 +3603,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 772,
+            "line": 795,
             "description": "The x range of the graph in pixels. The min and max pixel values\nin an array form.",
             "itemtype": "property",
             "name": "xRange",
@@ -3602,7 +3615,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 783,
+            "line": 806,
             "description": "Returns `true` if the graph has data to render. Data is conveyed\nto the graph by registered graphics.",
             "itemtype": "property",
             "name": "hasData",
@@ -3615,7 +3628,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 793,
+            "line": 816,
             "description": "The x coordinate position of the graph content",
             "itemtype": "property",
             "name": "graphX",
@@ -3627,7 +3640,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 809,
+            "line": 832,
             "description": "The y coordinate position of the graph content",
             "itemtype": "property",
             "name": "graphY",
@@ -3639,7 +3652,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 825,
+            "line": 848,
             "description": "The width, in pixels, of the graph content",
             "itemtype": "property",
             "name": "graphWidth",
@@ -3651,7 +3664,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 839,
+            "line": 862,
             "description": "The height, in pixels, of the graph content",
             "itemtype": "property",
             "name": "graphHeight",
@@ -3663,7 +3676,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 853,
+            "line": 876,
             "description": "An SVG transform to position the graph content",
             "itemtype": "property",
             "name": "graphTransform",
@@ -3675,7 +3688,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 865,
+            "line": 888,
             "description": "Sets `hasRendered` to `true` on `willInsertElement`.",
             "itemtype": "method",
             "name": "_notifyHasRendered",
@@ -3687,7 +3700,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 874,
+            "line": 897,
             "description": "Gets the mouse position relative to the container",
             "itemtype": "method",
             "name": "mousePoint",
@@ -3713,7 +3726,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 894,
+            "line": 917,
             "description": "A computed property returned the view's controller.",
             "itemtype": "property",
             "name": "parentController",
@@ -3725,7 +3738,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 902,
+            "line": 925,
             "description": "Selects the graphic passed. If `selectMultiple` is false, it will deselect the currently\nselected graphic if it's different from the one passed.",
             "itemtype": "method",
             "name": "selectGraphic",
@@ -3742,7 +3755,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 923,
+            "line": 946,
             "description": "deselects the graphic passed.",
             "itemtype": "method",
             "name": "deselectGraphic",
@@ -3759,7 +3772,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 940,
+            "line": 963,
             "description": "The initialization method. Fired on `init`.",
             "itemtype": "method",
             "name": "_setup",
@@ -3771,7 +3784,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 950,
+            "line": 973,
             "description": "The amount of leeway, in pixels, to give before triggering a brush start.",
             "itemtype": "property",
             "name": "brushThreshold",
@@ -3783,7 +3796,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 958,
+            "line": 981,
             "description": "The name of the action to trigger when brushing starts",
             "itemtype": "property",
             "name": "brushStartAction",
@@ -3795,7 +3808,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 966,
+            "line": 989,
             "description": "The name of the action to trigger when brushing emits a new value",
             "itemtype": "property",
             "name": "brushAction",
@@ -3807,7 +3820,7 @@
         },
         {
             "file": "app/components/nf-graph.js",
-            "line": 974,
+            "line": 997,
             "description": "The name of the action to trigger when brushing ends",
             "itemtype": "property",
             "name": "brushEndAction",
@@ -4913,6 +4926,162 @@
             "namespace": "components"
         },
         {
+            "file": "app/components/nf-tracker.js",
+            "line": 26,
+            "description": "Gets or sets the tracking mode of the component.\n\nPossible values are:\n\n- 'hover': only track while mouse hover\n- 'snap-last': track while mouse hover, but snap to the last data element when not hovering\n- 'snap-first': track while mouse hover, but snap to the first data element when not hovering\n- 'selected-hover': The same as `'hover'` tracking mode, but only when the compononent is \n{{#crossLink \"mixins.graph-selectable-graphic/selected:property\"}}{{/crossLink}}\n- 'selected-snap-last': The same as `'snap-last'` tracking mode, but only when the compononent is \n{{#crossLink \"mixins.graph-selectable-graphic/selected:property\"}}{{/crossLink}}\n- 'selected-snap-first': The same as `'snap-first'` tracking mode, but only when the compononent is \n{{#crossLink \"mixins.graph-selectable-graphic/selected:property\"}}{{/crossLink}}",
+            "itemtype": "property",
+            "name": "trackingMode",
+            "type": "String",
+            "default": "'hover'",
+            "class": "components.nf-tracker",
+            "module": "utils/nf/svg-dom",
+            "namespace": "components"
+        },
+        {
+            "file": "app/components/nf-tracker.js",
+            "line": 122,
+            "description": "The action name to send to the controller when the `hoverChange` event fires",
+            "itemtype": "property",
+            "name": "hoverChange",
+            "type": "String",
+            "default": "null",
+            "class": "components.nf-tracker",
+            "module": "utils/nf/svg-dom",
+            "namespace": "components"
+        },
+        {
+            "file": "app/components/nf-tracker.js",
+            "line": 130,
+            "description": "Event handler for content hoverChange event. Triggers `didHoverChange`.",
+            "itemtype": "method",
+            "name": "didContentHoverChange",
+            "params": [
+                {
+                    "name": "e",
+                    "description": "",
+                    "type": "utils.nf.graph-mouse-event"
+                }
+            ],
+            "access": "private",
+            "tagname": "",
+            "class": "components.nf-tracker",
+            "module": "utils/nf/svg-dom",
+            "namespace": "components"
+        },
+        {
+            "file": "app/components/nf-tracker.js",
+            "line": 146,
+            "description": "Event handler for didHoverChange. Sends hoverChange action.",
+            "itemtype": "method",
+            "name": "didHoverChange",
+            "params": [
+                {
+                    "name": "e",
+                    "description": "",
+                    "type": "utils.nf.graph-mouse-event"
+                }
+            ],
+            "class": "components.nf-tracker",
+            "module": "utils/nf/svg-dom",
+            "namespace": "components"
+        },
+        {
+            "file": "app/components/nf-tracker.js",
+            "line": 169,
+            "description": "Name of the action to send on `hoverEnd`",
+            "itemtype": "property",
+            "name": "hoverEnd",
+            "type": "String",
+            "default": "null",
+            "class": "components.nf-tracker",
+            "module": "utils/nf/svg-dom",
+            "namespace": "components"
+        },
+        {
+            "file": "app/components/nf-tracker.js",
+            "line": 177,
+            "description": "Event handler for didHoverEnd. Updates tracked data, and sends hoverEnd action.",
+            "itemtype": "method",
+            "name": "didHoverEnd",
+            "params": [
+                {
+                    "name": "e",
+                    "description": "hover end event object.",
+                    "type": "Object"
+                }
+            ],
+            "class": "components.nf-tracker",
+            "module": "utils/nf/svg-dom",
+            "namespace": "components"
+        },
+        {
+            "file": "app/components/nf-tracker.js",
+            "line": 198,
+            "description": "The action to send on `didTrack`.",
+            "itemtype": "property",
+            "name": "didTrack",
+            "type": "String",
+            "default": "null",
+            "class": "components.nf-tracker",
+            "module": "utils/nf/svg-dom",
+            "namespace": "components"
+        },
+        {
+            "file": "app/components/nf-tracker.js",
+            "line": 206,
+            "description": "Observes changes to tracked data and sends the\ndidTrack action.",
+            "itemtype": "method",
+            "name": "_sendDidTrack",
+            "access": "private",
+            "tagname": "",
+            "class": "components.nf-tracker",
+            "module": "utils/nf/svg-dom",
+            "namespace": "components"
+        },
+        {
+            "file": "app/components/nf-tracker.js",
+            "line": 224,
+            "description": "The action to send on `willTrack`",
+            "itemtype": "property",
+            "name": "willTrack",
+            "type": "String",
+            "default": "null",
+            "class": "components.nf-tracker",
+            "module": "utils/nf/svg-dom",
+            "namespace": "components"
+        },
+        {
+            "file": "app/components/nf-tracker.js",
+            "line": 238,
+            "description": "Observes impending changes to trackedData and sends\nthe willTrack action.",
+            "itemtype": "method",
+            "name": "_sendWillTrack",
+            "access": "private",
+            "tagname": "",
+            "class": "components.nf-tracker",
+            "module": "utils/nf/svg-dom",
+            "namespace": "components"
+        },
+        {
+            "file": "app/components/nf-tracker.js",
+            "line": 256,
+            "description": "Handles the graph-content's hoverEnd event and triggers didHoverEnd",
+            "itemtype": "method",
+            "name": "didContentHoverEnd",
+            "params": [
+                {
+                    "name": "e",
+                    "description": "",
+                    "type": "utils.nf.graph-mouse-action-context"
+                }
+            ],
+            "access": "private",
+            "tagname": "",
+            "class": "components.nf-tracker",
+            "module": "utils/nf/svg-dom",
+            "namespace": "components"
+        },
+        {
             "file": "app/components/nf-vertical-line.js",
             "line": 20,
             "description": "The top y coordinate of the line",
@@ -4968,7 +5137,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 50,
+            "line": 48,
             "description": "The height of the x axis in pixels.",
             "itemtype": "property",
             "name": "height",
@@ -4980,7 +5149,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 58,
+            "line": 56,
             "description": "The number of ticks to display",
             "itemtype": "property",
             "name": "tickCount",
@@ -4992,7 +5161,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 66,
+            "line": 64,
             "description": "The length of the tick line (the small vertical line indicating the tick)",
             "itemtype": "property",
             "name": "tickLength",
@@ -5004,7 +5173,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 74,
+            "line": 72,
             "description": "The spacing between the end of the tick line and the origin of the templated\ntick content",
             "itemtype": "property",
             "name": "tickPadding",
@@ -5016,7 +5185,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 83,
+            "line": 81,
             "description": "The orientation of the x axis. Value can be `'top'` or `'bottom'`.",
             "itemtype": "property",
             "name": "orient",
@@ -5028,14 +5197,14 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 93,
+            "line": 91,
             "description": "An optional filtering function to allow more control over what tick marks are displayed.\nThe function should have exactly the same signature as the function you'd use for an\n`Array.prototype.filter()`.",
             "itemtype": "property",
             "name": "tickFilter",
             "type": "Function",
             "default": "null",
             "example": [
-                "\n\n      {{#nf-x-axis tickFilter=myFilter}}\n        <text>{{tick.value}}</text>\n      {{/nf-x-axis}}\n\nAnd on your controller:\n\n      myFilter: function(tick, index, ticks) {\n        return tick.value < 1000;\n      },\n\nThe above example will filter down the set of ticks to only those that are less than 1000."
+                "\n\n      {{#nf-x-axis tickFilter=myFilter as |tick|}}\n        <text>{{tick.value}}</text>\n      {{/nf-x-axis}}\n\nAnd on your controller:\n\n      myFilter: function(tick, index, ticks) {\n        return tick.value < 1000;\n      },\n\nThe above example will filter down the set of ticks to only those that are less than 1000."
             ],
             "class": "components.nf-x-axis",
             "module": "utils/nf/svg-dom",
@@ -5043,7 +5212,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 117,
+            "line": 115,
             "description": "The class applied due to orientation (e.g. `'orient-top'`)",
             "itemtype": "property",
             "name": "orientClass",
@@ -5055,7 +5224,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 127,
+            "line": 125,
             "description": "The SVG Transform applied to this component's container.",
             "itemtype": "property",
             "name": "transform",
@@ -5067,7 +5236,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 139,
+            "line": 137,
             "description": "The y position of this component's container.",
             "itemtype": "property",
             "name": "y",
@@ -5079,7 +5248,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 169,
+            "line": 167,
             "description": "This x position of this component's container",
             "itemtype": "property",
             "name": "x",
@@ -5091,7 +5260,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 185,
+            "line": 182,
             "description": "The width of the component",
             "itemtype": "property",
             "name": "width",
@@ -5103,7 +5272,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 193,
+            "line": 190,
             "description": "A method to call to override the default behavior of how ticks are created.\n\nThe function signature should match:\n\n      // - scale: d3.Scale\n      // - tickCount: number of ticks\n      // - uniqueData: unique data points for the axis\n      // - scaleType: string of \"linear\" or \"ordinal\"\n      // returns: an array of tick values.\n      function(scale, tickCount, uniqueData, scaleType) {\n        return [100,200,300];\n      }",
             "itemtype": "property",
             "name": "tickFactory",
@@ -5115,7 +5284,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 231,
+            "line": 228,
             "description": "A unique set of all x data on the graph",
             "itemtype": "property",
             "name": "uniqueXData",
@@ -5127,7 +5296,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 239,
+            "line": 236,
             "description": "The models for the ticks to display on the axis.",
             "itemtype": "property",
             "name": "ticks",
@@ -5139,7 +5308,7 @@
         },
         {
             "file": "app/components/nf-x-axis.js",
-            "line": 285,
+            "line": 282,
             "description": "The y position, in pixels, of the axis line",
             "itemtype": "property",
             "name": "axisLineY",
@@ -5151,7 +5320,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 45,
+            "line": 43,
             "description": "The number of ticks to display",
             "itemtype": "property",
             "name": "tickCount",
@@ -5163,7 +5332,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 53,
+            "line": 51,
             "description": "The length of the tick's accompanying line.",
             "itemtype": "property",
             "name": "tickLength",
@@ -5175,7 +5344,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 61,
+            "line": 59,
             "description": "The distance between the tick line and the origin tick's templated output",
             "itemtype": "property",
             "name": "tickPadding",
@@ -5187,7 +5356,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 69,
+            "line": 67,
             "description": "The total width of the y axis",
             "itemtype": "property",
             "name": "width",
@@ -5199,7 +5368,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 77,
+            "line": 75,
             "description": "The orientation of the y axis. Possible values are `'left'` and `'right'`",
             "itemtype": "property",
             "name": "orient",
@@ -5211,14 +5380,14 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 91,
+            "line": 89,
             "description": "An optional filtering function to allow more control over what tick marks are displayed.\nThe function should have exactly the same signature as the function you'd use for an\n`Array.prototype.filter()`.",
             "itemtype": "property",
             "name": "tickFilter",
             "type": "Function",
             "default": "null",
             "example": [
-                "\n  \n      {{#nf-y-axis tickFilter=myFilter}} \n        <text>{{tick.value}}</text>\n      {{/nf-y-axis}}\n  \nAnd on your controller:\n\n      myFilter: function(tick, index, ticks) {\n        return tick.value < 1000;\n      },\n  \nThe above example will filter down the set of ticks to only those that are less than 1000."
+                "\n\n      {{#nf-y-axis tickFilter=myFilter as |tick|}}\n        <text>{{tick.value}}</text>\n      {{/nf-y-axis}}\n  \nAnd on your controller:\n\n      myFilter: function(tick, index, ticks) {\n        return tick.value < 1000;\n      },\n  \nThe above example will filter down the set of ticks to only those that are less than 1000."
             ],
             "class": "components.nf-y-axis",
             "module": "utils/nf/svg-dom",
@@ -5226,7 +5395,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 120,
+            "line": 118,
             "description": "computed property. returns true if `orient` is equal to `'right'`.",
             "itemtype": "property",
             "name": "isOrientRight",
@@ -5238,7 +5407,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 129,
+            "line": 127,
             "description": "The SVG transform for positioning the component.",
             "itemtype": "property",
             "name": "transform",
@@ -5250,7 +5419,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 141,
+            "line": 139,
             "description": "The x position of the component",
             "itemtype": "property",
             "name": "x",
@@ -5262,7 +5431,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 162,
+            "line": 160,
             "description": "The y position of the component",
             "itemtype": "property",
             "name": "y",
@@ -5274,7 +5443,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 170,
+            "line": 168,
             "description": "the height of the component",
             "itemtype": "property",
             "name": "height",
@@ -5286,7 +5455,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 184,
+            "line": 181,
             "description": "A method to call to override the default behavior of how ticks are created.\n\nThe function signature should match:\n\n      // - scale: d3.Scale\n      // - tickCount: number of ticks\n      // - uniqueData: unique data points for the axis\n      // - scaleType: string of \"linear\" or \"ordinal\"\n      // returns: an array of tick values.\n      function(scale, tickCount, uniqueData, scaleType) {\n        return [100,200,300];\n      }",
             "itemtype": "property",
             "name": "tickFactory",
@@ -5298,7 +5467,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 229,
+            "line": 226,
             "description": "All y data from the graph, filtered to unique values.",
             "itemtype": "property",
             "name": "uniqueYData",
@@ -5310,7 +5479,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 237,
+            "line": 234,
             "description": "The ticks to be displayed.",
             "itemtype": "property",
             "name": "ticks",
@@ -5322,7 +5491,7 @@
         },
         {
             "file": "app/components/nf-y-axis.js",
-            "line": 281,
+            "line": 278,
             "description": "The x position of the axis line.",
             "itemtype": "property",
             "name": "axisLineX",
@@ -5579,6 +5748,18 @@
         {
             "message": "replacing incorrect tag: params with param",
             "line": " addon/mixins/graph-graphic-with-tracking-dot.js:158"
+        },
+        {
+            "message": "replacing incorrect tag: params with param",
+            "line": " app/components/nf-tracker.js:130"
+        },
+        {
+            "message": "replacing incorrect tag: function with method",
+            "line": " app/components/nf-tracker.js:177"
+        },
+        {
+            "message": "replacing incorrect tag: params with param",
+            "line": " app/components/nf-tracker.js:177"
         }
     ]
 }

--- a/docs/files/addon_mixins_graph-area-utils.js.html
+++ b/docs/files/addon_mixins_graph-area-utils.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_mixins_graph-data-graphic.js.html
+++ b/docs/files/addon_mixins_graph-data-graphic.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -122,6 +123,8 @@ import parsePropertyExpr from &#x27;../utils/parse-property-expression&#x27;;
 import { nearestIndexTo } from &#x27;../utils/nf/array-helpers&#x27;;
 import computed from &#x27;ember-new-computed&#x27;;
 
+var { on, observer } = Ember;
+
 var noop = function(){};
 
 /**
@@ -147,6 +150,31 @@ export default Ember.Mixin.create({
     @default null
   */
   data: null,
+
+  mappedData: computed(&#x27;data.@each&#x27;, {
+    get() {
+      var yPropFn = this.get(&#x27;yPropFn&#x27;);
+      var xPropFn = this.get(&#x27;xPropFn&#x27;);
+      var data = this.get(&#x27;data&#x27;);
+      if(Ember.isArray(data)) {
+        return data.map(function(d, i) {
+          var item = [xPropFn(d), yPropFn(d)];
+          item.data = d;
+          item.origIndex = i;
+          return item;
+        });
+      }
+      return [];
+    }
+  }),
+
+  _triggerHasData: on(&#x27;init&#x27;, observer(&#x27;data.@each&#x27;, function(){
+    Ember.run.once(this, this._sendTriggerHasData);
+  })),
+
+  _sendTriggerHasData() {
+    this.trigger(&#x27;hasData&#x27;, this.get(&#x27;mappedData&#x27;));
+  },
 
   /**
     The path of the property on each object in 
@@ -201,107 +229,37 @@ export default Ember.Mixin.create({
   }),
 
   /**
-    Gets the x values from the &#x60;sortedData&#x60;.
-    @property xData
-    @type Array
-    @readonly
-  */
-  xData: null,
-
-  /**
-    Gets the y values from the &#x60;sortedData&#x60;
-    @property yData
-    @type Array
-    @readonly
-  */
-  yData: null,
-
-  /**
-    The sorted and mapped data pulled from {{#crossLink &quot;mixins.graph-data-graphic/data:property&quot;}}{{/crossLink}}
-    An array of arrays, structures as so:
-
-          [[x,y],[x,y],[x,y]];
-
-    ** each inner array also has a property &#x60;data&#x60; on it, containing the original data object **
-
-    When this property is computed, it also updates the &#x60;xData&#x60; and &#x60;yData&#x60; properties of the graphic.
-    @property sortedData
-    @type Array
-    @readonly
-  */
-  sortedData: computed(&#x27;data.@each&#x27;, &#x27;xPropFn&#x27;, &#x27;yPropFn&#x27;, {
-    get() {
-      var data = this.get(&#x27;data&#x27;);
-      var xPropFn = this.get(&#x27;xPropFn&#x27;);
-      var yPropFn = this.get(&#x27;yPropFn&#x27;);
-      var xScaleType = this.get(&#x27;xScaleType&#x27;);
-
-      if(!data) {
-        return null;
-      }
-
-      var mapped = data.map(function(d, i) {
-        var item = [xPropFn(d), yPropFn(d)];
-        item.data = d;
-        item.origIndex = i;
-        return item;
-      });
-
-      if(xScaleType !== &#x27;ordinal&#x27;) {
-        mapped.sort(function(a, b) {
-          var ax = a[0];
-          var bx = b[0];
-          return ax === bx ? 0 : (ax &gt; bx) ? 1 : -1;
-        });
-      }
-
-      var xData = [];
-      var yData = [];
-      
-      mapped.forEach(function(d) {
-        xData.push(d[0]);
-        yData.push(d[1]);
-      });
-
-      this.set(&#x27;xData&#x27;, xData);
-      this.set(&#x27;yData&#x27;, yData);
-      
-      return mapped;
-    }
-  }),
-
-  /**
-    The list of data points from {{#crossLink &quot;mixins.graph-data-graphc/sortedData:property&quot;}}{{/crossLink}} that
+    The list of data points from {{#crossLink &quot;mixins.graph-data-graphc/mappedData:property&quot;}}{{/crossLink}} that
     fits within the x domain, plus up to one data point outside of that domain in each direction.
     @property renderedData
     @type Array
     @readonly
   */
   renderedData: computed(
-    &#x27;sortedData.@each&#x27;,
+    &#x27;mappedData.@each&#x27;,
     &#x27;graph.xScaleType&#x27;,
     &#x27;graph.xMin&#x27;,
     &#x27;graph.xMax&#x27;,
     {
       get() {
-        var sortedData = this.get(&#x27;sortedData&#x27;);
+        var mappedData = this.get(&#x27;mappedData&#x27;);
         var graph = this.get(&#x27;graph&#x27;);
         var xScaleType = graph.get(&#x27;xScaleType&#x27;);
         var xMin = graph.get(&#x27;xMin&#x27;);
         var xMax = graph.get(&#x27;xMax&#x27;);
 
-        if(!sortedData || sortedData.length === 0) {
+        if(!mappedData || mappedData.length === 0) {
           return [];
         }
 
         if(xScaleType === &#x27;ordinal&#x27;) {
-          return sortedData.slice();
+          return mappedData;
         }
 
-        return sortedData.filter(function(d, i) {
+        return mappedData.filter(function(d, i) {
           var x = d[0];
-          var prev = sortedData[i-1];
-          var next = sortedData[i+1];
+          var prev = mappedData[i-1];
+          var next = mappedData[i+1];
           var prevX = prev ? prev[0] : null;
           var nextX = next ? next[0] : null;
 

--- a/docs/files/addon_mixins_graph-has-graph-parent.js.html
+++ b/docs/files/addon_mixins_graph-has-graph-parent.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_mixins_graph-line-utils.js.html
+++ b/docs/files/addon_mixins_graph-line-utils.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_mixins_graph-registered-graphic.js.html
+++ b/docs/files/addon_mixins_graph-registered-graphic.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_mixins_graph-requires-scale-source.js.html
+++ b/docs/files/addon_mixins_graph-requires-scale-source.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_mixins_graph-selectable-graphic.js.html
+++ b/docs/files/addon_mixins_graph-selectable-graphic.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_utils_nf_array-helpers.js.html
+++ b/docs/files/addon_utils_nf_array-helpers.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_utils_nf_graph-event.js.html
+++ b/docs/files/addon_utils_nf_graph-event.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_utils_nf_graph-mouse-event.js.html
+++ b/docs/files/addon_utils_nf_graph-mouse-event.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_utils_nf_graph-position.js.html
+++ b/docs/files/addon_utils_nf_graph-position.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_utils_nf_scale-utils.js.html
+++ b/docs/files/addon_utils_nf_scale-utils.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_utils_nf_scroll-area-action-context.js.html
+++ b/docs/files/addon_utils_nf_scroll-area-action-context.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_utils_nf_svg-dom.js.html
+++ b/docs/files/addon_utils_nf_svg-dom.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/addon_utils_parse-property-expression.js.html
+++ b/docs/files/addon_utils_parse-property-expression.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-area-stack.js.html
+++ b/docs/files/app_components_nf-area-stack.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -152,6 +153,22 @@ export default Ember.Component.extend({
     @readonly
   */
   isAreaStack: true,
+
+  /**
+    Whether or not to add the values together to create the stacked area
+    @property aggregate
+    @type {boolean}
+    @default false
+  */
+  aggregate: Ember.computed(function(key, value) {
+    if(arguments.length &gt; 1) {
+      this._aggregate = value;
+    } else if(typeof this._aggregate === &#x27;undefined&#x27;) {
+      Ember.warn(&#x27;nf-area-stack.aggregate must be set. Currently defaulting to &#x60;false&#x60; but will default to &#x60;true&#x60; in the future.&#x27;)
+      this._aggregate = false;
+    }
+    return this._aggregate;
+  }),
 
   /**
     The collection of &#x60;nf-area&#x60; components under this stack.

--- a/docs/files/app_components_nf-area.js.html
+++ b/docs/files/app_components_nf-area.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -197,31 +198,29 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
       @type Array
       @readonly
     */
-    nextYData: Ember.computed(&#x27;renderedData.length&#x27;, &#x27;nextArea.renderedData.@each&#x27;, function(){
-      var nextData = this.get(&#x27;nextArea.renderedData&#x27;) || [];
-      var renderedDataLength = this.get(&#x27;renderedData.length&#x27;);
-        
-      var result = nextData.map(function(next) {
-        return next[1];
-      });
-      
-      while(result.length &lt; renderedDataLength) {
-        result.push(-99999999);
+    nextYData: Ember.computed(&#x27;data.length&#x27;, &#x27;nextArea.data.@each&#x27;, function(){
+      var data = this.get(&#x27;data&#x27;);
+      if(!Array.isArray(data)) {
+        return [];
       }
-
-      return result;
+      var nextData = this.get(&#x27;nextArea.mappedData&#x27;);
+      return data.map((d, i) =&gt; (nextData &amp;&amp; nextData[i] &amp;&amp; nextData[i][1]) || Number.MIN_VALUE);
     }),
 
     /**
       The current rendered data &quot;zipped&quot; together with the nextYData.
-      @property areaData
+      @property mappedData
       @type Array
       @readonly
     */
-    areaData: Ember.computed(&#x27;renderedData.@each&#x27;, &#x27;nextYData.@each&#x27;, function(){
-      var nextYData = this.get(&#x27;nextYData&#x27;);
-      return this.get(&#x27;renderedData&#x27;).map(function(r, i) {
-        return [r[0], r[1], nextYData[i]];
+    mappedData: Ember.computed(&#x27;data.[]&#x27;, &#x27;xPropFn&#x27;, &#x27;yPropFn&#x27;, &#x27;nextYData.@each&#x27;, &#x27;stack.aggregate&#x27;, function() {
+      var { data, xPropFn, yPropFn, nextYData } = this.getProperties(&#x27;data&#x27;, &#x27;xPropFn&#x27;, &#x27;yPropFn&#x27;, &#x27;nextYData&#x27;);
+      var aggregate = this.get(&#x27;stack.aggregate&#x27;);
+      return data.map((d, i) =&gt; {
+        var x = xPropFn(d);
+        var y = yPropFn(d);
+        var result = aggregate ? [x, y + nextYData[i], nextYData[i]] : [x, y, nextYData[i]];
+        return result;
       });
     }),
 
@@ -245,9 +244,9 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
       @type String
       @readonly
     */
-    d: Ember.computed(&#x27;areaData&#x27;, &#x27;areaFn&#x27;, function(){
-      var areaData = this.get(&#x27;areaData&#x27;);
-      return this.get(&#x27;areaFn&#x27;)(areaData);
+    d: Ember.computed(&#x27;renderedData&#x27;, &#x27;areaFn&#x27;, function(){
+      var renderedData = this.get(&#x27;renderedData&#x27;);
+      return this.get(&#x27;areaFn&#x27;)(renderedData);
     }),
 
     click: function(){

--- a/docs/files/app_components_nf-bars.js.html
+++ b/docs/files/app_components_nf-bars.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-crosshair.js.html
+++ b/docs/files/app_components_nf-crosshair.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-dot.js.html
+++ b/docs/files/app_components_nf-dot.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-gg.js.html
+++ b/docs/files/app_components_nf-gg.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-graph-content.js.html
+++ b/docs/files/app_components_nf-graph-content.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-graph.js.html
+++ b/docs/files/app_components_nf-graph.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -355,11 +356,11 @@ var maxProperty = function(axis, defaultTickCount) {
   ## More advanced example
 
        {{#nf-graph width=500 height=300}}
-         {{#nf-x-axis height=&quot;50&quot;}}
+         {{#nf-x-axis height=&quot;50&quot; as |tick|}}
            &lt;text&gt;{{tick.value}}&lt;/text&gt;
          {{/nf-x-axis}}
-   
-         {{#nf-y-axis width=&quot;120&quot;}}
+
+         {{#nf-y-axis width=&quot;120&quot; as |tick|}}
            &lt;text&gt;{{tick.value}}&lt;/text&gt;
          {{/nf-y-axis}}
    
@@ -713,15 +714,31 @@ export default Ember.Component.extend({
   */
   yMaxMode: &#x27;auto&#x27;,
 
+  dataExtents: Ember.computed(&#x27;graphics.@each.data&#x27;, function(){
+    var graphics = this.get(&#x27;graphics&#x27;);
+    return graphics.reduce((c, x) =&gt; c.concat(x.get(&#x27;mappedData&#x27;)), []).reduce((extents, [x, y]) =&gt; {
+      extents.xMin = extents.xMin &lt; x ? extents.xMin : x;
+      extents.xMax = extents.xMax &gt; x ? extents.xMax : x;
+      extents.yMin = extents.yMin &lt; y ? extents.yMin : y;
+      extents.yMax = extents.yMax &gt; y ? extents.yMax : y;
+      return extents;
+    }, {
+      xMin: Number.MAX_VALUE,
+      xMax: Number.MIN_VALUE,
+      yMin: Number.MAX_VALUE,
+      yMax: Number.MIN_VALUE
+    })
+  }),
+
   /**
     Gets the highest and lowest x values of the graphed data in a two element array.
     @property xDataExtent
     @type Array
     @readonly
   */
-  xDataExtent: Ember.computed(&#x27;xData&#x27;, function(){
-    var xData = this.get(&#x27;xData&#x27;);
-    return xData ? d3.extent(xData) : [null, null];
+  xDataExtent: Ember.computed(&#x27;dataExtents&#x27;, function(){
+    var { xMin, xMax } = this.get(&#x27;dataExtents&#x27;);
+    return [xMin, xMax];
   }),
 
   /**
@@ -730,9 +747,9 @@ export default Ember.Component.extend({
     @type Array
     @readonly
   */
-  yDataExtent: Ember.computed(&#x27;yData&#x27;, function(){
-    var yData = this.get(&#x27;yData&#x27;);
-    return yData ? d3.extent(yData) : [null, null];
+  yDataExtent: Ember.computed(&#x27;dataExtents&#x27;, function(){
+    var { yMin, yMax } = this.get(&#x27;dataExtents&#x27;);
+    return [yMin, yMax];
   }),
 
   /**
@@ -865,6 +882,7 @@ export default Ember.Component.extend({
   registerGraphic: function (graphic) {
     var graphics = this.get(&#x27;graphics&#x27;);
     graphics.pushObject(graphic);
+    graphic.on(&#x27;hasData&#x27;, this, this.updateExtents);
   },
 
   /**
@@ -873,10 +891,16 @@ export default Ember.Component.extend({
     @param graphic {Ember.Component} The component to unregister
    */
   unregisterGraphic: function(graphic) {
+    graphic.off(&#x27;hasData&#x27;, this, this.updateExtents);
     var graphics = this.get(&#x27;graphics&#x27;);
     graphics.removeObject(graphic);
   },
   
+  updateExtents(data) {
+    this.get(&#x27;xDataExtent&#x27;);
+    this.get(&#x27;yDataExtent&#x27;);
+  },
+
   /**
     The y range of the graph in pixels. The min and max pixel values
     in an array form.

--- a/docs/files/app_components_nf-horizontal-line.js.html
+++ b/docs/files/app_components_nf-horizontal-line.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-line.js.html
+++ b/docs/files/app_components_nf-line.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-plot.js.html
+++ b/docs/files/app_components_nf-plot.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-plots.js.html
+++ b/docs/files/app_components_nf-plots.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-range-marker.js.html
+++ b/docs/files/app_components_nf-range-marker.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-range-markers.js.html
+++ b/docs/files/app_components_nf-range-markers.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-right-tick.js.html
+++ b/docs/files/app_components_nf-right-tick.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-selection-box.js.html
+++ b/docs/files/app_components_nf-selection-box.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-svg-image.js.html
+++ b/docs/files/app_components_nf-svg-image.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-svg-line.js.html
+++ b/docs/files/app_components_nf-svg-line.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-svg-path.js.html
+++ b/docs/files/app_components_nf-svg-path.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-svg-rect.js.html
+++ b/docs/files/app_components_nf-svg-rect.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-tracker.js.html
+++ b/docs/files/app_components_nf-tracker.js.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>addon/mixins/graph-graphic-with-tracking-dot.js - ember-nf-graph</title>
+    <title>app/components/nf-tracker.js - ember-nf-graph</title>
     <link rel="stylesheet" href="http://yui.yahooapis.com/3.9.1/build/cssgrids/cssgrids-min.css">
     <link rel="stylesheet" href="../assets/vendor/prettify/prettify-min.css">
     <link rel="stylesheet" href="../assets/css/main.css" id="site_styles">
@@ -114,31 +114,40 @@
             <div class="apidocs">
                 <div id="docs-main">
                     <div class="content">
-<h1 class="file-heading">File: addon/mixins/graph-graphic-with-tracking-dot.js</h1>
+<h1 class="file-heading">File: app/components/nf-tracker.js</h1>
 
 <div class="file">
     <pre class="code prettyprint linenums">
 import Ember from &#x27;ember&#x27;;
-import GraphMouseEvent from &#x27;../utils/nf/graph-mouse-event&#x27;;
+import GraphMouseEvent from &#x27;ember-nf-graph/utils/nf/graph-mouse-event&#x27;;
+import DataGraphic from &#x27;ember-nf-graph/mixins/graph-data-graphic&#x27;;
+import RequiresScaleSource from &#x27;ember-nf-graph/mixins/graph-requires-scale-source&#x27;;
+import HasGraphParent from &#x27;ember-nf-graph/mixins/graph-has-graph-parent&#x27;;
 import computed from &#x27;ember-new-computed&#x27;;
 
 const get = Ember.get;
 const { or } = Ember.computed;
 
 /**
-  Adds tracking dot functionality to a component such as {{#crossLink &quot;components.nf-line&quot;}}{{/crossLink}}
-  or {{#crossLink &quot;components.nf-area&quot;}}{{/crossLink}}
-  
-  @namespace mixins
-  @class graph-graphic-with-tracking-dot
+  A tracking graphic component used to do things like create tracking dots for nf-area or nf-line.
+  @namespace components
+  @class nf-tracker
+  @uses mixins.graph-has-graph-parent
+  @uses mixins.graph-data-graphic
+  @uses mixins.graph-requires-scale-source
   */
-export default Ember.Mixin.create({
+export default Ember.Component.extend(HasGraphParent, DataGraphic, RequiresScaleSource, {
+  tagName: &#x27;g&#x27;,
+
+  classNameBindings: [&#x27;:nf-tracker&#x27;],
+
+  attributeBindings: [&#x27;transform&#x27;],
+
   /**
     Gets or sets the tracking mode of the component.
 
     Possible values are:
 
-    - &#x27;none&#x27;: no tracking behavior
     - &#x27;hover&#x27;: only track while mouse hover
     - &#x27;snap-last&#x27;: track while mouse hover, but snap to the last data element when not hovering
     - &#x27;snap-first&#x27;: track while mouse hover, but snap to the first data element when not hovering
@@ -151,13 +160,13 @@ export default Ember.Mixin.create({
 
     @property trackingMode
     @type String
-    @default &#x27;none&#x27;
+    @default &#x27;hover&#x27;
   */
-  trackingMode: &#x27;none&#x27;,
+  trackingMode: &#x27;hover&#x27;,
+
+  isTracker: true,
 
   trackedData: null,
-
-  trackingDotRadius: 2.5,
 
   isShouldTrack: or(&#x27;isSelectedHoverMode&#x27;, &#x27;isHoverMode&#x27;),
 
@@ -179,7 +188,17 @@ export default Ember.Mixin.create({
 
   isHovered: false,
 
-  showTrackingDot: computed(&#x27;trackedData.x&#x27;, &#x27;trackedData.y&#x27;, {
+  transform: computed(&#x27;trackedData.x&#x27;, &#x27;trackedData.y&#x27;, &#x27;xScale&#x27;, &#x27;yScale&#x27;, {
+    get() {
+      var xScale = this.get(&#x27;xScale&#x27;);
+      var yScale = this.get(&#x27;yScale&#x27;);
+      var x = xScale &amp;&amp; xScale(this.get(&#x27;trackedData.x&#x27;) || 0);
+      var y = yScale &amp;&amp; yScale(this.get(&#x27;trackedData.y&#x27;) || 0);
+      return &#x27;translate(&#x27; + x + &#x27;,&#x27; + y + &#x27;)&#x27;;
+    }
+  }),
+
+  showTracker: computed(&#x27;trackedData.graphX&#x27;, &#x27;trackedData.graphY&#x27;, {
     get() {
       var trackedData = this.get(&#x27;trackedData&#x27;);
       if(trackedData) {
@@ -234,7 +253,7 @@ export default Ember.Mixin.create({
     @params e {utils.nf.graph-mouse-event}
     @private
   */
-  didContentHoverChange: function(e){
+  didContentHoverChange(e){
     var graphContentElement = this.get(&#x27;graphContentElement&#x27;);
 
     this.trigger(&#x27;didHoverChange&#x27;, GraphMouseEvent.create({
@@ -249,7 +268,7 @@ export default Ember.Mixin.create({
     @method didHoverChange
     @param e {utils.nf.graph-mouse-event}
   */
-  didHoverChange: function(e) {
+  didHoverChange(e) {
     var isHoverMode = this.get(&#x27;isHoverMode&#x27;);
     var isSelectedHoverMode = this.get(&#x27;isSelectedHoverMode&#x27;);
     var selected = this.get(&#x27;selected&#x27;);
@@ -280,7 +299,7 @@ export default Ember.Mixin.create({
     @function didHoverEnd
     @params e {Object} hover end event object.
   */
-  didHoverEnd: function(e) {
+  didHoverEnd(e) {
     this.set(&#x27;hoverData&#x27;, null);
 
     if(this.get(&#x27;isHovered&#x27;)) {
@@ -360,7 +379,7 @@ export default Ember.Mixin.create({
     @param e {utils.nf.graph-mouse-action-context}
     @private
   */
-  didContentHoverEnd: function(e){
+  didContentHoverEnd(e){
     var graph = this.get(&#x27;graph&#x27;);
 
     this.trigger(&#x27;didHoverEnd&#x27;, {
@@ -370,29 +389,21 @@ export default Ember.Mixin.create({
     });
   },
 
-  /**
-    Sets up subscriptions to content hover events.
-    @method _initializeTrackingDot
-    @private
-  */
-  _initializeTrackingDot: Ember.on(&#x27;didInsertElement&#x27;, function(){
+  didInsertElement() {
+    this._super.apply(arguments);
     var content = this.get(&#x27;graph.content&#x27;);
     content.on(&#x27;didHoverChange&#x27;, this, this.didContentHoverChange);
     content.on(&#x27;didHoverEnd&#x27;, this, this.didContentHoverEnd);
-  }),
+  },
 
-  /**
-    Tears down subscriptions to content hover events.
-    @method _teardownTrackingDot
-    @private
-  */
-  _teardownTrackingDot: Ember.on(&#x27;willDestroyElement&#x27;, function(){
+  willDestroyElement(){
+    this._super.apply(arguments);
     var content = this.get(&#x27;graph.content&#x27;);
     if(content) {
       content.off(&#x27;didHoverChange&#x27;, this, this.didContentHoverChange);
       content.off(&#x27;didHoverEnd&#x27;, this, this.didContentHoverEnd);
     }
-  })
+  }
 });
     </pre>
 </div>

--- a/docs/files/app_components_nf-vertical-line.js.html
+++ b/docs/files/app_components_nf-vertical-line.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/files/app_components_nf-x-axis.js.html
+++ b/docs/files/app_components_nf-x-axis.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -142,7 +143,7 @@ import layout from &#x27;../templates/components/nf-x-axis&#x27;;
   ### Example
 
         {{#nf-graph width=500 height=300}}
-          {{#nf-x-axis height=40}}
+          {{#nf-x-axis height=40 as |tick|}}
             &lt;text&gt;x is {{tick.value}}&lt;/text&gt;
           {{/nf-x-axis}}
         {{/nf-graph}}
@@ -159,8 +160,6 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
 
   layout: layout,
   template: null,
-
-  useDefaultTemplate: Ember.computed.equal(&#x27;template&#x27;, null),
 
   attributeBindings: [&#x27;transform&#x27;],
   classNameBindings: [&#x27;orientClass&#x27;],
@@ -219,7 +218,7 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @default null
     @example
 
-          {{#nf-x-axis tickFilter=myFilter}}
+          {{#nf-x-axis tickFilter=myFilter as |tick|}}
             &lt;text&gt;{{tick.value}}&lt;/text&gt;
           {{/nf-x-axis}}
 
@@ -298,7 +297,6 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
   init() {
     this._super(...arguments);
     this.set(&#x27;graph.xAxis&#x27;, this);
-    Ember.deprecate(&#x27;Non-block form of tick is deprecated. Please add &#x60;as |tick|&#x60; to your template.&#x27;, this.get(&#x27;template.blockParams&#x27;));
   },
 
   /**

--- a/docs/files/app_components_nf-y-axis.js.html
+++ b/docs/files/app_components_nf-y-axis.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -142,7 +143,7 @@ import layout from &#x27;../templates/components/nf-y-axis&#x27;;
   ### Example
 
         {{#nf-graph width=500 height=300}}
-          {{#nf-y-axis width=40}}
+          {{#nf-y-axis width=40 as |tick|}}
             &lt;text&gt;y is {{tick.value}}&lt;/text&gt;
           {{/nf-y-axis}}
         {{/nf-graph}}
@@ -158,8 +159,6 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
 
   layout: layout,
   template: null,
-
-  useDefaultTemplate: Ember.computed.equal(&#x27;template&#x27;, null),
 
   /**
     The number of ticks to display
@@ -216,8 +215,8 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Function
     @default null
     @example
-  
-          {{#nf-y-axis tickFilter=myFilter}} 
+
+          {{#nf-y-axis tickFilter=myFilter as |tick|}}
             &lt;text&gt;{{tick.value}}&lt;/text&gt;
           {{/nf-y-axis}}
   
@@ -297,7 +296,6 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
   init() {
     this._super(...arguments);
     this.set(&#x27;graph.yAxis&#x27;, this);
-    Ember.deprecate(&#x27;Non-block form of tick is deprecated. Please add &#x60;as |tick|&#x60; to your template.&#x27;, this.get(&#x27;template.blockParams&#x27;));
   },
 
   /**

--- a/docs/files/app_components_nf-y-diff.js.html
+++ b/docs/files/app_components_nf-y-diff.js.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,6 +57,7 @@
                                 <li><a href="./classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="./classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="./classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="./classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="./classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="./classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="./classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/modules/scale-utils.html
+++ b/docs/modules/scale-utils.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/modules/utils_nf_array-helpers.html
+++ b/docs/modules/utils_nf_array-helpers.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>

--- a/docs/modules/utils_nf_svg-dom.html
+++ b/docs/modules/utils_nf_svg-dom.html
@@ -57,6 +57,7 @@
                                 <li><a href="../classes/components.nf-svg-line.html">components.nf-svg-line</a></li>
                                 <li><a href="../classes/components.nf-svg-path.html">components.nf-svg-path</a></li>
                                 <li><a href="../classes/components.nf-svg-rect.html">components.nf-svg-rect</a></li>
+                                <li><a href="../classes/components.nf-tracker.html">components.nf-tracker</a></li>
                                 <li><a href="../classes/components.nf-vertical-line.html">components.nf-vertical-line</a></li>
                                 <li><a href="../classes/components.nf-x-axis.html">components.nf-x-axis</a></li>
                                 <li><a href="../classes/components.nf-y-axis.html">components.nf-y-axis</a></li>
@@ -227,6 +228,11 @@
                 <li class="module-class">
                     <a href="../classes/components.nf-svg-rect.html">
                         components.nf-svg-rect
+                    </a>
+                </li>
+                <li class="module-class">
+                    <a href="../classes/components.nf-tracker.html">
+                        components.nf-tracker
                     </a>
                 </li>
                 <li class="module-class">

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-cli-htmlbars": "^0.7.6",
     "ember-cli-ic-ajax": "^0.1.2",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^0.3.11",
+    "ember-cli-qunit": "^0.3.14",
     "ember-cli-uglify": "^1.0.1",
     "ember-disable-prototype-extensions": "^1.0.1",
     "ember-export-application-global": "^1.0.2",

--- a/tests/dummy/app/templates/nf-graph/index.hbs
+++ b/tests/dummy/app/templates/nf-graph/index.hbs
@@ -29,6 +29,8 @@
 			{{nf-selection-box xMin=10 xMax=50 yMin=diffA yMax=diffB}}
 		{{/nf-gg}}
 
+		{{#nf-tracker data=model.lineData as |d|}}<text>{{d.x}}, {{d.y}}</text>{{/nf-tracker}}
+
 		{{!-- {{nf-svg-rect x=1 y=diffA width=2 height=diffB}} --}}
 		{{!-- 
 		{{#nf-plots data=model.lineData action="showData" scaleZoomY=multiY}}

--- a/tests/dummy/app/templates/nf-graph/index.hbs
+++ b/tests/dummy/app/templates/nf-graph/index.hbs
@@ -81,14 +81,14 @@
 	}
 </style>
 
-{{#nf-graph  xLink=groupX selectMultiple=1
+{{#nf-graph yMaxMode="fixed" yMax=500 xLink=groupX selectMultiple=1
 	brushStartAction="brushStart"
 	brushAction="brush"
 	brushEndAction="brushEnd"
 	width=graphWidth height=graphHeight showFrets="true" showLanes="true" paddingTop=50}}
 
 	{{#nf-graph-content}}
-		{{#nf-area-stack}}
+		{{#nf-area-stack aggregate=1}}
 			{{nf-area class="area3" selectable=1 selected=fooSelected interpolator="linear" data=model.area3  trackingMode="snap-last"}}
 			{{nf-area class="area2" selectable=1 interpolator="linear" data=model.area2  trackingMode="snap-last"}}
 			{{nf-area class="area1" selectable=1 interpolator="linear" data=model.area1  trackingMode="snap-last"}}

--- a/tests/unit/addon/mixins/graph-data-graphic-test.js
+++ b/tests/unit/addon/mixins/graph-data-graphic-test.js
@@ -4,148 +4,152 @@ import { module, test } from 'qunit';
 
 module('addon/mixins/graph-data-graphic');
 
-test('sortedData should sort data into array of arrays by x property', assert => {
-  var Foo = Ember.Object.extend(GraphDataGraphic);
-
-  var foo = Foo.create({
-    data: [{ x: 123, y: 3 }, { x: 42, y: 2 }, { x: 1, y: 1 }],
-    xprop: 'x',
-    yprop: 'y',
-  });
-
-  var sortedData = foo.get('sortedData');
-  var xData = foo.get('xData');
-  var yData = foo.get('yData');
-
-  assert.deepEqual(sortedData, [[1,1],[42,2],[123,3]]);
-  assert.deepEqual(xData, [1,42,123]);
-  assert.deepEqual(yData, [1,2,3]);
-});
-
 test('renderedData should narrow sortedData down to only what is between xMin and xMax if non-ordinal xScaleType, PLUS one point to either side', assert => {
-  var Foo = Ember.Object.extend(GraphDataGraphic);
-  var foo = Foo.create({
-    sortedData: [[1,1], [75, 2], [100, 3], [101, 4], [150, 5], [199, 6], [200, 7], [225, 8], [300, 9]],
-    graph: Ember.Object.create({
-      xScaleType: 'linear',
-      xMin: 100,
-      xMax: 200
-    })
-  });
+  var Foo = Ember.Component.extend(GraphDataGraphic, Ember.Evented);
+  Ember.run(() => {
+    var foo = Foo.create({
+      mappedData: [[1,1], [75, 2], [100, 3], [101, 4], [150, 5], [199, 6], [200, 7], [225, 8], [300, 9]],
+      graph: Ember.Object.create({
+        xScaleType: 'linear',
+        xMin: 100,
+        xMax: 200
+      })
+    });
 
-  var renderedData = foo.get('renderedData');
-  assert.deepEqual(renderedData, [[75, 2], [100, 3], [101, 4], [150, 5], [199, 6], [200, 7], [225, 8]]);
+    var renderedData = foo.get('renderedData');
+    assert.deepEqual(renderedData, [[75, 2], [100, 3], [101, 4], [150, 5], [199, 6], [200, 7], [225, 8]]);
+  });
 });
 
 test('renderedData should return the whole sortedData array if xScaleType is "ordinal"', assert => {
-  var Foo = Ember.Object.extend(GraphDataGraphic);
-  var foo = Foo.create({
-    sortedData: [[1,1], [75, 2], [100, 3], [101, 4], [150, 5], [199, 6], [200, 7], [225, 8], [300, 9]],
-    graph: Ember.Object.create({
-      xScaleType: 'ordinal',
-      xMin: 100,
-      xMax: 200
-    })
-  });
+  var Foo = Ember.Component.extend(GraphDataGraphic);
+  Ember.run(() => {
+    var foo = Foo.create({
+      mappedData: [[1,1], [75, 2], [100, 3], [101, 4], [150, 5], [199, 6], [200, 7], [225, 8], [300, 9]],
+      graph: Ember.Object.create({
+        xScaleType: 'ordinal',
+        xMin: 100,
+        xMax: 200
+      })
+    });
 
-  var renderedData = foo.get('renderedData');
-  assert.deepEqual(renderedData, [[1,1], [75, 2], [100, 3], [101, 4], [150, 5], [199, 6], [200, 7], [225, 8], [300, 9]]);
+    var renderedData = foo.get('renderedData');
+    assert.deepEqual(renderedData, [[1,1], [75, 2], [100, 3], [101, 4], [150, 5], [199, 6], [200, 7], [225, 8], [300, 9]]);
+  });
 });
 
 test('firstVisibleData returns the first item of renderedData that is actually visible if renderedData includes a value off-graph', assert => {
-  var Foo = Ember.Object.extend(GraphDataGraphic);
-  var foo = Foo.create({
-    renderedData: [[1,1],[2,2],[3,3],[4,4],[5,5]],
-    xMin: 1.4
-  });
+  var Foo = Ember.Component.extend(GraphDataGraphic);
+    Ember.run(() => {
+    var foo = Foo.create({
+      renderedData: [[1,1],[2,2],[3,3],[4,4],[5,5]],
+      xMin: 1.4
+    });
 
-  var firstVisibleData = foo.get('firstVisibleData');
-  assert.deepEqual(firstVisibleData, { x: 2, y: 2, data: undefined });
+    var firstVisibleData = foo.get('firstVisibleData');
+    assert.deepEqual(firstVisibleData, { x: 2, y: 2, data: undefined });
+  });
 });
 
 test('firstVisibleData returns the first item of renderedData if it is at the xMin exactly', assert => {
-  var Foo = Ember.Object.extend(GraphDataGraphic);
-  var foo = Foo.create({
-    renderedData: [[1,1],[2,2],[3,3],[4,4],[5,5]],
-    xMin: 1
-  });
+  var Foo = Ember.Component.extend(GraphDataGraphic);
+  Ember.run(() => {
+    var foo = Foo.create({
+      renderedData: [[1,1],[2,2],[3,3],[4,4],[5,5]],
+      xMin: 1
+    });
 
-  var firstVisibleData = foo.get('firstVisibleData');
-  assert.deepEqual(firstVisibleData, { x: 1, y: 1, data: undefined });
+    var firstVisibleData = foo.get('firstVisibleData');
+    assert.deepEqual(firstVisibleData, { x: 1, y: 1, data: undefined });
+  });
 });
 
 test('lastVisibleData returns the last item of renderedData that is actually visible if renderedData includes a value off-graph', assert => {
-  var Foo = Ember.Object.extend(GraphDataGraphic);
-  var foo = Foo.create({
-    renderedData: [[1,1],[2,2],[3,3],[4,4],[5,5]],
-    xMax: 4.4
-  });
+  var Foo = Ember.Component.extend(GraphDataGraphic);
+  Ember.run(() => {
+    var foo = Foo.create({
+      renderedData: [[1,1],[2,2],[3,3],[4,4],[5,5]],
+      xMax: 4.4
+    });
 
-  var lastVisibleData = foo.get('lastVisibleData');
-  assert.deepEqual(lastVisibleData, { x: 4, y: 4, data: undefined });
+    var lastVisibleData = foo.get('lastVisibleData');
+    assert.deepEqual(lastVisibleData, { x: 4, y: 4, data: undefined });
+  });
 });
 
 test('lastVisibleData returns the last item of renderedData if it is at the xMax exactly', assert => {
-  var Foo = Ember.Object.extend(GraphDataGraphic);
-  var foo = Foo.create({
-    renderedData: [[1,1],[2,2],[3,3],[4,4],[5,5]],
-    xMax: 5
-  });
+  var Foo = Ember.Component.extend(GraphDataGraphic);
+  Ember.run(() => {
+    var foo = Foo.create({
+      renderedData: [[1,1],[2,2],[3,3],[4,4],[5,5]],
+      xMax: 5
+    });
 
-  var lastVisibleData = foo.get('lastVisibleData');
-  assert.deepEqual(lastVisibleData, { x: 5, y: 5, data: undefined });
+    var lastVisibleData = foo.get('lastVisibleData');
+    assert.deepEqual(lastVisibleData, { x: 5, y: 5, data: undefined });
+  });
 });
 
 test('getDataNearX() should return the data point closest to the x domain value passed', assert => {
-  var Foo = Ember.Object.extend(GraphDataGraphic);
-  var foo = Foo.create({
-    renderedData: [[1,1],[2,2],[3,3],[4,4],[5,5]]
-  });
+  var Foo = Ember.Component.extend(GraphDataGraphic);
+  Ember.run(() => {
+    var foo = Foo.create({
+      renderedData: [[1,1],[2,2],[3,3],[4,4],[5,5]]
+    });
 
-  var data = foo.getDataNearX(3.6);
-  assert.deepEqual(data, [4,4]);
-  
-  var data2 = foo.getDataNearX(3.3);
-  assert.deepEqual(data2, [3,3]);
+    var data = foo.getDataNearX(3.6);
+    assert.deepEqual(data, [4,4]);
+    
+    var data2 = foo.getDataNearX(3.3);
+    assert.deepEqual(data2, [3,3]);
+  });
 });
 
 test('xPropFn should be a function that gets the value specified by xprop', assert => {
-  var Foo = Ember.Object.extend(GraphDataGraphic);
-  var foo = Foo.create({
-    xprop: 'foo.bar'
-  });
+  var Foo = Ember.Component.extend(GraphDataGraphic);
+  Ember.run(() => {
+    var foo = Foo.create({
+      xprop: 'foo.bar'
+    });
 
-  var fn = foo.get('xPropFn');
-  assert.equal(fn({ foo: { bar: 'wokka wokka' } }), 'wokka wokka');
+    var fn = foo.get('xPropFn');
+    assert.equal(fn({ foo: { bar: 'wokka wokka' } }), 'wokka wokka');
+  });
 });
 
 test('xPropFn should work if xprop uses an array index like so: foo[2]', assert => {
-  var Foo = Ember.Object.extend(GraphDataGraphic);
-  var foo = Foo.create({
-    xprop: 'foo[2]'
-  });
+  var Foo = Ember.Component.extend(GraphDataGraphic);
+  Ember.run(() => {
+    var foo = Foo.create({
+      xprop: 'foo[2]'
+    });
 
-  var fn = foo.get('xPropFn');
-  assert.equal(fn({ foo: ['apple', 'orange', 'banana'] }), 'banana');
+    var fn = foo.get('xPropFn');
+    assert.equal(fn({ foo: ['apple', 'orange', 'banana'] }), 'banana');
+  });
 });
 
 test('yPropFn should be a function that gets the value specified by yprop', assert => {
-  var Foo = Ember.Object.extend(GraphDataGraphic);
-  var foo = Foo.create({
-    yprop: 'foo.bar'
-  });
+  var Foo = Ember.Component.extend(GraphDataGraphic);
+  Ember.run(() => {
+    var foo = Foo.create({
+      yprop: 'foo.bar'
+    });
 
-  var fn = foo.get('yPropFn');
-  assert.equal(fn({ foo: { bar: 'wokka wokka' } }), 'wokka wokka');
+    var fn = foo.get('yPropFn');
+    assert.equal(fn({ foo: { bar: 'wokka wokka' } }), 'wokka wokka');
+  });
 });
 
 
 test('yPropFn should work if yprop uses an array index like so: foo[2]', assert => {
-  var Foo = Ember.Object.extend(GraphDataGraphic);
-  var foo = Foo.create({
-    yprop: 'foo[2]'
-  });
+  var Foo = Ember.Component.extend(GraphDataGraphic);
+  Ember.run(() => {
+    var foo = Foo.create({
+      yprop: 'foo[2]'
+    });
 
-  var fn = foo.get('yPropFn');
-  assert.equal(fn({ foo: ['apple', 'orange', 'banana'] }), 'banana');
+    var fn = foo.get('yPropFn');
+    assert.equal(fn({ foo: ['apple', 'orange', 'banana'] }), 'banana');
+  });
 });

--- a/tests/unit/app/components/nf-bars-test.js
+++ b/tests/unit/app/components/nf-bars-test.js
@@ -1,3 +1,5 @@
+import Ember from 'ember';
+
 import {
   moduleForComponent,
   test
@@ -11,30 +13,32 @@ moduleForComponent('nf-bars', {
 });
 
 test('bars layout', function(assert) {
-  var nfBars = this.subject();
+  var bars;
 
-  nfBars.setProperties({
-    xScale: x => { 
-      switch(x) {
-        case 'a':
-          return 0;
-        case 'b':
-          return 10;
-        case 'c':
-          return 20;
-      }
-    },
-    yScale: x => x,
-    renderedData: [ ['a', 10], ['b', 5], ['c', 1] ],
-    graphHeight: 10,
-    getBarClass: () => 'testClass',
-    barWidth: 10,
-    groupOffsetX: 30,
-    _getRectPath: (...args) => args
+  Ember.run(() => {
+    var nfBars = this.subject({
+        xScale: x => { 
+          switch(x) {
+            case 'a':
+              return 0;
+            case 'b':
+              return 10;
+            case 'c':
+              return 20;
+          }
+        },
+        yScale: x => x,
+        renderedData: [ ['a', 10], ['b', 5], ['c', 1] ],
+        graphHeight: 10,
+        getBarClass: () => 'testClass',
+        barWidth: 10,
+        groupOffsetX: 30,
+        _getRectPath: (...args) => args
+      });
+
+      bars = nfBars.get('bars');
   });
-
-  var bars = nfBars.get('bars');
-
+  
   assert.deepEqual(bars, [{
     path: [30, 10, 10, 0],
     className: 'nf-bars-bar testClass',

--- a/tests/unit/app/components/nf-horizontal-line-test.js
+++ b/tests/unit/app/components/nf-horizontal-line-test.js
@@ -1,3 +1,5 @@
+import Ember from 'ember';
+
 import {
   moduleForComponent,
   test
@@ -23,8 +25,10 @@ test('it renders', function(assert) {
 test('lineY pins to zero', function(assert) {
   var component = this.subject();
 
-  component.set('yScale', function() { return -99; });
-  component.set('y', 0);
+  Ember.run(() => {
+    component.set('yScale', function() { return -99; });
+    component.set('y', 0);
+  });
 
   assert.equal(component.get('lineY'), 0);
 });

--- a/tests/unit/app/components/nf-vertical-line-test.js
+++ b/tests/unit/app/components/nf-vertical-line-test.js
@@ -1,3 +1,5 @@
+import Ember from 'ember';
+
 import {
   moduleForComponent,
   test
@@ -23,8 +25,10 @@ test('it renders', function(assert) {
 test('lineX pins to zero', function(assert) {
   var component = this.subject();
 
-  component.set('xScale', function() { return -99; });
-  component.set('x', 0);
+  Ember.run(() => {
+    component.set('xScale', function() { return -99; });
+    component.set('x', 0);
+  });
 
   assert.equal(component.get('lineX'), 0);
 });

--- a/tests/unit/app/components/nf-x-axis-test.js
+++ b/tests/unit/app/components/nf-x-axis-test.js
@@ -14,22 +14,24 @@ moduleForComponent('nf-x-axis', {
 test('nf-x-axis tickData should call tickFactory if available', function(assert) {
   var args;
 
-  //HACK: couldn't find a great, documented way of mocking readonly and aliased propertied
-  // so I override them here.
-  var axis = this.factory().extend({
-    uniqueXData: [1,2,3,4,5],
-    xScale: 'xScale',
-    graph: Ember.computed((key, value) => ({
-      xScaleType: 'xScaleType'
-    })),
-    tickCount: 42,
-    tickFactory: function() {
-      args = [].slice.call(arguments);
-      return 'expected result';
-    }
-  }).create();
+  Ember.run(() => {
+    //HACK: couldn't find a great, documented way of mocking readonly and aliased propertied
+    // so I override them here.
+    var axis = this.factory().extend({
+      uniqueXData: [1,2,3,4,5],
+      xScale: 'xScale',
+      graph: Ember.computed((key, value) => ({
+        xScaleType: 'xScaleType'
+      })),
+      tickCount: 42,
+      tickFactory: function() {
+        args = [].slice.call(arguments);
+        return 'expected result';
+      }
+    }).create();
 
-  var tickData = axis.get('tickData');
-  assert.equal(tickData, 'expected result');
-  assert.deepEqual(args, ['xScale', 42, [1,2,3,4,5], 'xScaleType']);
+    var tickData = axis.get('tickData');
+    assert.equal(tickData, 'expected result');
+    assert.deepEqual(args, ['xScale', 42, [1,2,3,4,5], 'xScaleType']);
+  });
 });

--- a/tests/unit/app/components/nf-y-axis-test.js
+++ b/tests/unit/app/components/nf-y-axis-test.js
@@ -12,23 +12,24 @@ moduleForComponent('nf-y-axis', {
 
 test('nf-y-axis tickData should call tickFactory if available', function(assert) {
   var args;
+  Ember.run(() => {
+    //HACK: couldn't find a great, documented way of mocking readonly and aliased propertied
+    // so I override them here.
+    var axis = this.factory().extend({
+      uniqueYData: [1,2,3,4,5],
+      yScale: 'yScale',
+      graph: Ember.computed((key, value) => ({
+        yScaleType: 'yScaleType'
+      })),
+      tickCount: 42,
+      tickFactory: function() {
+        args = [].slice.call(arguments);
+        return 'expected result';
+      }
+    }).create();
 
-  //HACK: couldn't find a great, documented way of mocking readonly and aliased propertied
-  // so I override them here.
-  var axis = this.factory().extend({
-    uniqueYData: [1,2,3,4,5],
-    yScale: 'yScale',
-    graph: Ember.computed((key, value) => ({
-      yScaleType: 'yScaleType'
-    })),
-    tickCount: 42,
-    tickFactory: function() {
-      args = [].slice.call(arguments);
-      return 'expected result';
-    }
-  }).create();
-
-  var tickData = axis.get('tickData');
-  assert.equal(tickData, 'expected result');
-  assert.deepEqual(args, ['yScale', 42, [1,2,3,4,5], 'yScaleType']);
+    var tickData = axis.get('tickData');
+    assert.equal(tickData, 'expected result');
+    assert.deepEqual(args, ['yScale', 42, [1,2,3,4,5], 'yScaleType']);
+  });
 });


### PR DESCRIPTION
- added `aggregate` attribute to `nf-area-stack` component.
  - if `true`: Y values will some for each area in the graph.
  - if `false`: (Old behavior) values are expected to be pre-aggregated

- added `nf-tracker` component. this is a template-able component for creating things like tracking dots.

- switched `nf-line` and `nf-area` to use `nf-tracker` internally for their tracking modes.

- graphics will no longer sort the data, this was done for performance reasons. Data is expected to be pre-sorted for graphing purposes.

- changed the method by which min and max domain values were updated on the graph for performance reasons.