### PR TITLE
fix issue caused by hasBlock not existing in 1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### master
+### v1.0.0-beta.17
 
 - ADD `nf-tracker` component. This is a component for templatable tracking dots
 - UPDATE `nf-line` and `nf-area` to use `nf-tracker` for tracking dot generation

--- a/app/components/nf-x-axis.js
+++ b/app/components/nf-x-axis.js
@@ -41,6 +41,12 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
   layout: layout,
   template: null,
 
+  useTemplate: Ember.computed('hasBlock', 'template.blockParams', 'hasBlockParams', function(){
+    var preGlimmerCheck = this.get('template.blockParams');
+    var postGlimmerCheck = this.get('hasBlock') && this.get('hasBlockParams');
+    return Boolean(postGlimmerCheck || preGlimmerCheck);
+  }),
+
   attributeBindings: ['transform'],
   classNameBindings: ['orientClass'],
   classNames: ['nf-x-axis'],

--- a/app/components/nf-y-axis.js
+++ b/app/components/nf-y-axis.js
@@ -40,6 +40,12 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
   layout: layout,
   template: null,
 
+  useTemplate: Ember.computed(function(){
+    var preGlimmerCheck = this.get('template.blockParams');
+    var postGlimmerCheck = this.get('hasBlock') && this.get('hasBlockParams');
+    return Boolean(postGlimmerCheck || preGlimmerCheck);
+  }),
+
   /**
     The number of ticks to display
     @property tickCount

--- a/app/templates/components/nf-x-axis.hbs
+++ b/app/templates/components/nf-x-axis.hbs
@@ -2,7 +2,7 @@
 
 {{#each ticks as |tick|}}
   <g class="tick">
-    {{#if hasBlock}}
+    {{#if useTemplate}}
       {{#nf-tick-label x=tick.x y=tick.labely}}
         {{yield tick}}
       {{/nf-tick-label}}

--- a/app/templates/components/nf-y-axis.hbs
+++ b/app/templates/components/nf-y-axis.hbs
@@ -2,7 +2,7 @@
 
 {{#each ticks as |tick|}}
   <g class="tick">
-    {{#if hasBlock}}
+    {{#if useTemplate}}
       {{#nf-tick-label x=tick.labelx y=tick.y}}
         {{yield tick}}
       {{/nf-tick-label}}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-nf-graph",
-  "version": "1.0.0-beta.16",
-  "description": "The default blueprint for ember-cli addons.",
+  "version": "1.0.0-beta.17",
+  "description": "A graphing/charting DSL for Ember.js",
   "files": [
     "addon/",
     "app/",

--- a/tests/unit/app/components/nf-x-axis-test.js
+++ b/tests/unit/app/components/nf-x-axis-test.js
@@ -35,3 +35,34 @@ test('nf-x-axis tickData should call tickFactory if available', function(assert)
     assert.deepEqual(args, ['xScale', 42, [1,2,3,4,5], 'xScaleType']);
   });
 });
+
+test('nf-x-axis useTemplate if template.blockParams', function(assert) {
+  Ember.run(() => {
+    var axis = this.factory().extend({
+      graph: Ember.computed((key, value) => ({
+        xScaleType: 'xScaleType'
+      }))
+    }).create();
+
+    axis.set('template', Ember.Object.create({
+      blockParams: true
+    }));
+
+    assert.equal(axis.get('useTemplate'), true);
+  });
+});
+
+
+test('nf-x-axis useTemplate if hasBlock AND hasBlockParams', function(assert) {
+  Ember.run(() => {
+    var axis = this.factory().extend({
+      graph: Ember.computed((key, value) => ({
+        xScaleType: 'xScaleType'
+      })),
+      hasBlock: true,
+      hasBlockParams: true
+    }).create();
+
+    assert.equal(axis.get('useTemplate'), true);
+  });
+});

--- a/tests/unit/app/components/nf-y-axis-test.js
+++ b/tests/unit/app/components/nf-y-axis-test.js
@@ -33,3 +33,35 @@ test('nf-y-axis tickData should call tickFactory if available', function(assert)
     assert.deepEqual(args, ['yScale', 42, [1,2,3,4,5], 'yScaleType']);
   });
 });
+
+
+test('nf-y-axis useTemplate if template.blockParams', function(assert) {
+  Ember.run(() => {
+    var axis = this.factory().extend({
+      graph: Ember.computed((key, value) => ({
+        yScaleType: 'yScaleType'
+      }))
+    }).create();
+
+    axis.set('template', Ember.Object.create({
+      blockParams: true
+    }));
+
+    assert.equal(axis.get('useTemplate'), true);
+  });
+});
+
+
+test('nf-y-axis useTemplate if hasBlock AND hasBlockParams', function(assert) {
+  Ember.run(() => {
+    var axis = this.factory().extend({
+      graph: Ember.computed((key, value) => ({
+        yScaleType: 'yScaleType'
+      })),
+      hasBlock: true,
+      hasBlockParams: true
+    }).create();
+
+    assert.equal(axis.get('useTemplate'), true);
+  });
+});


### PR DESCRIPTION
The changes to support glimmer included a change to use `hasBlock` in templates. The problem is that doesn't exist in older versions of Ember. To support this, I've added an `isHasBlock` computed property to the axis components that will check the "new way" and the "old way" (templates.blockParams truthiness)