### PR TITLE
Add events/actions out for auto scaling on x and y domain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:

--- a/app/components/nf-graph.js
+++ b/app/components/nf-graph.js
@@ -121,6 +121,7 @@ var minProperty = function(axis, defaultTickCount){
   var _ScaleFactory_ = axis + 'ScaleFactory';
   var __Min_ = '_' + axis + 'Min';
   var _prop_ = axis + 'Min';
+  var _autoScaleEvent_ = 'didAutoUpdateMin' + axis.toUpperCase();
 
   return Ember.computed(
     _MinMode_,
@@ -136,6 +137,7 @@ var minProperty = function(axis, defaultTickCount){
       } else {
         var change = function(val) {
           this.set(_prop_, val);
+          this.trigger(_autoScaleEvent_);
         }.bind(this);
 
         if(mode === 'auto') {
@@ -173,6 +175,7 @@ var maxProperty = function(axis, defaultTickCount) {
   var _MaxMode_ = axis + 'MaxMode';
   var __Max_ = '_' + axis + 'Max';
   var _prop_ = axis + 'Max';
+  var _autoScaleEvent_ = 'didAutoUpdateMax' + axis.toUpperCase();
 
   return Ember.computed(
     _MaxMode_,
@@ -188,6 +191,7 @@ var maxProperty = function(axis, defaultTickCount) {
       } else {
         var change = function(val) {
           this.set(_prop_, val);
+          this.trigger(_autoScaleEvent_);
         }.bind(this);
 
         if(mode === 'auto') {
@@ -609,6 +613,55 @@ export default Ember.Component.extend({
       yMax: Number.MIN_VALUE
     })
   }),
+
+  /**
+    The action to trigger when the graph automatically updates the xScale 
+    due to an "auto" "push" or "push-tick" domainMode.
+
+    sends the xDataExtent value as the argument.
+
+    @property autoScaleXAction
+    @type {string}
+    @default null
+  */
+  autoScaleXAction: null,
+
+  _sendAutoUpdateXAction() {
+    this.sendAction('autoScaleXAction', this.get('xDataExtent'));
+  },
+
+  _sendAutoUpdateYAction() {
+    this.sendAction('autoScaleYAction', this.get('yDataExtent'));
+  },
+
+  didAutoUpdateMaxX() {
+    Ember.run.once(this, this._sendAutoUpdateXAction);
+  },
+
+  didAutoUpdateMinX() {
+    Ember.run.once(this, this._sendAutoUpdateXAction);
+  },
+
+
+  didAutoUpdateMaxY() {
+    Ember.run.once(this, this._sendAutoUpdateYAction);
+  },
+
+  didAutoUpdateMinY() {
+    Ember.run.once(this, this._sendAutoUpdateYAction);
+  },
+
+  /**
+    The action to trigger when the graph automatically updates the yScale 
+    due to an "auto" "push" or "push-tick" domainMode.
+
+    Sends the yDataExtent value as the argument.
+
+    @property autoScaleYAction
+    @type {string}
+    @default null
+  */
+  autoScaleYAction: null,
 
   /**
     Gets the highest and lowest x values of the graphed data in a two element array.

--- a/app/components/nf-graph.js
+++ b/app/components/nf-graph.js
@@ -135,10 +135,12 @@ var minProperty = function(axis, defaultTickCount){
       if(arguments.length > 1) {
         this[__Min_] = value;
       } else {
+        var self = this;
+
         var change = function(val) {
-          this.set(_prop_, val);
-          this.trigger(_autoScaleEvent_);
-        }.bind(this);
+          self.set(_prop_, val);
+          self.trigger(_autoScaleEvent_);
+        };
 
         if(mode === 'auto') {
           change(this.get(_DataExtent_)[0] || 0);
@@ -189,10 +191,12 @@ var maxProperty = function(axis, defaultTickCount) {
       if(arguments.length > 1) {
         this[__Max_] = value;
       } else {
+        var self = this;
+
         var change = function(val) {
-          this.set(_prop_, val);
-          this.trigger(_autoScaleEvent_);
-        }.bind(this);
+          self.set(_prop_, val);
+          self.trigger(_autoScaleEvent_);
+        };
 
         if(mode === 'auto') {
           change(this.get(_DataExtent_)[1] || 1);
@@ -1058,10 +1062,6 @@ export default Ember.Component.extend({
   _setupBrushAction: Ember.on('didInsertElement', function(){
     var content = this.$('.nf-graph-content');
 
-    var toBrushEventStreams = this._toBrushEventStreams.bind(this);
-    var toComponentEventStream = this._toComponentEventStream;
-    var triggerComponentEvent = this._triggerComponentEvent.bind(this);
-
     var mouseMoves = Observable.fromEvent(content, 'mousemove');
     var mouseDowns = Observable.fromEvent(content, 'mousedown');
     var mouseUps = Observable.fromEvent(Ember.$(document), 'mouseup');
@@ -1072,30 +1072,26 @@ export default Ember.Component.extend({
       window(mouseDowns, function() { return mouseUps; })
       // filter out all of them if there are no brush actions registered
       // map the mouse event streams into brush event streams
-      .map( toBrushEventStreams ).
+      .map(x => this._toBrushEventStreams(x)).
       // flatten to a stream of action names and event objects
-      flatMap( toComponentEventStream ).
+      flatMap(x => this._toComponentEventStream(x)).
       // HACK: this is fairly cosmetic, so skip errors.
       retry().
       // subscribe and send the brush actions via Ember
-      forEach(triggerComponentEvent);
+      forEach(x => this._triggerComponentEvent(x));
   }),
 
   _toBrushEventStreams: function(mouseEvents) {
-    var getStartInfo = this._getStartInfo;
-    var byBrushThreshold = this._byBrushThreshold.bind(this);
-    var toBrushEvent = this._toBrushEvent.bind(this);
-
     // get the starting mouse event
     return mouseEvents.take(1).
       // calculate it's mouse point and info
-      map( getStartInfo ).
+      map( this._getStartInfo ).
       // combine the start with the each subsequent mouse event
       combineLatest(mouseEvents.skip(1), toArray).
       // filter out everything until the brushThreshold is crossed
-      filter( byBrushThreshold ).
+      filter(x => this._byBrushThreshold(x)).
       // create the brush event object
-      map( toBrushEvent );
+      map(x => this._toBrushEvent(x));
   },
 
   _triggerComponentEvent: function(d) {

--- a/tests/unit/app/components/nf-graph-test.js
+++ b/tests/unit/app/components/nf-graph-test.js
@@ -1,0 +1,167 @@
+import Ember from 'ember';
+
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('nf-graph', {});
+
+['push', 'auto', 'push-tick'].forEach((mode) => 
+  test('changing xDataExtent[0] with xMinMode = "' + mode + '" should trigger didAutoUpdateMinX()', function(assert) {
+    assert.expect(1);
+
+    var graph = this.subject({
+      xMinMode: mode,
+      xMin: 0,
+      xMax: 100,
+      didAutoUpdateMinX() {
+        assert.ok(true);
+      }
+    });
+
+    Ember.run(() => {
+      graph.set('xDataExtent', [-1, 100]);
+      graph.get('xMin');
+    });
+  })
+);
+
+test('changing xDataExtent[0] with xMinMode = "fixed" should NOT trigger didAutoUpdateMinX()', function(assert) {
+  assert.expect(0);
+
+  var graph = this.subject({
+    xMinMode: 'fixed',
+    xMin: 0,
+    xMax: 100,
+    didAutoUpdateMinX() {
+      assert.ok(false);
+    }
+  });
+
+  Ember.run(() => {
+    graph.set('xDataExtent', [-1, 100]);
+    graph.get('xMin');
+  });
+});
+
+
+['push', 'auto', 'push-tick'].forEach((mode) => 
+  test('changing xDataExtent[0] with xMaxMode = "' + mode + '" should trigger didAutoUpdateMaxX()', function(assert) {
+    assert.expect(1);
+
+    var graph = this.subject({
+      xMaxMode: mode,
+      xMin: 0,
+      xMax: 100,
+      didAutoUpdateMaxX() {
+        assert.ok(true);
+      }
+    });
+
+    Ember.run(() => {
+      graph.set('xDataExtent', [0, 101]);
+      graph.get('xMax');
+    });
+  })
+);
+
+
+test('changing xDataExtent[0] with xMaxMode = "fixed" should trigger NOT didAutoUpdateMaxX()', function(assert) {
+  assert.expect(0);
+
+  var graph = this.subject({
+    xMaxMode: 'fixed',
+    xMin: 0,
+    xMax: 100,
+    didAutoUpdateMaxX() {
+      assert.ok(false);
+    }
+  });
+
+  Ember.run(() => {
+    graph.set('xDataExtent', [0, 101]);
+    graph.get('xMax');
+  });
+});
+
+test('calling didAutoUpdateMaxX() should send xDataExtent over autoScaleXAction', function(assert){
+  assert.expect(1);
+
+  var calledWith;
+
+  var graph = this.subject({
+    xDataExtent: [1,2],
+    sendAction() {
+      calledWith = [].slice.call(arguments);
+    }
+  });
+
+  Ember.run(() => {
+    graph.didAutoUpdateMaxX();
+  });
+
+  assert.deepEqual(calledWith, ['autoScaleXAction', [1,2]]);
+});
+
+test('calling didAutoUpdateMinX() should send xDataExtent over autoScaleXAction', function(assert){
+  assert.expect(1);
+
+  var calledWith;
+
+  var graph = this.subject({
+    xDataExtent: [1,2],
+    sendAction() {
+      calledWith = [].slice.call(arguments);
+    }
+  });
+
+  Ember.run(() => {
+    graph.didAutoUpdateMinX();
+  });
+
+  assert.deepEqual(calledWith, ['autoScaleXAction', [1,2]]);
+});
+
+//-----
+
+
+test('calling didAutoUpdateMinY() should send yDataExtent over autoScaleYAction', function(assert){
+  assert.expect(1);
+
+  var calledWith;
+
+  var graph = this.subject({
+    yDataExtent: [1,2],
+    sendAction() {
+      calledWith = [].slice.call(arguments);
+    }
+  });
+
+  Ember.run(() => {
+    graph.didAutoUpdateMinY();
+  });
+
+  assert.deepEqual(calledWith, ['autoScaleYAction', [1,2]]);
+});
+
+test('calling didAutoUpdateMaxY() should send yDataExtent over autoScaleYAction', function(assert){
+  assert.expect(1);
+
+  var calledWith;
+
+  var graph = this.subject({
+    yDataExtent: [1,2],
+    sendAction() {
+      calledWith = [].slice.call(arguments);
+    }
+  });
+
+  Ember.run(() => {
+    graph.didAutoUpdateMaxY();
+  });
+
+  assert.deepEqual(calledWith, ['autoScaleYAction', [1,2]]);
+});
+
+


### PR DESCRIPTION
Basically, if xMin, xMax, yMin or yMax automatically changes because of a `push-tick`, `push` or `auto` mode (e.g. xMinMode), an event will fire and an action will be triggered such as `autoScaleXAction`, that gets the `xDataExtent` sent to it.

This is useful for balancing scales between multiple graphs that are using things like `yMaxMode="push-tick"`