### PR TITLE
Readd hoverData output on tracked components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### master
+
+- UPDATE Readd `hoverData` output to tracked components.
+
 ### 1.0.0-beta.26
 
 - FIX Ensure tracked data updates when firstVisibleData or lastVisibleData has updated in certain tracking modes

--- a/addon/mixins/graph-graphic-with-tracking-dot.js
+++ b/addon/mixins/graph-graphic-with-tracking-dot.js
@@ -43,6 +43,43 @@ export default Ember.Mixin.create({
   */
   didTrack: null,
 
+  /**
+    The value of the data that is being tracked by the component.
+    @property trackedData
+    @type {Object} an object with the following values:  
+      - point: an { x, y } pair for the exact px coordinates inside the graph-content
+      - graphX: domain x value at mouse position
+      - graphY: domain y value at mouse position
+      - x: nearest x data value
+      - y: nearest y data value
+      - data: nearest raw data
+      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+      - mouseX: mouse x position in pixels
+      - mouseY: mouse y position in pixels
+    @default null
+  */
+  trackedData: null,
+
+  /**
+    The value of the data that is being tracked by the component, ONLY if the 
+    graph-content is currently being hovered.
+    @property hoverData
+    @type {Object} an object with the following values:  
+      - point: an { x, y } pair for the exact px coordinates inside the graph-content
+      - graphX: domain x value at mouse position
+      - graphY: domain y value at mouse position
+      - x: nearest x data value
+      - y: nearest y data value
+      - data: nearest raw data
+      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+      - mouseX: mouse x position in pixels
+      - mouseY: mouse y position in pixels
+    @default null
+  */
+  hoverData: null,
+
   _showTrackingDot: true,
 
   /**
@@ -64,15 +101,18 @@ export default Ember.Mixin.create({
   /**
     Observes changes to tracked data and sends the
     didTrack action.
-    @method _sendDidTrack
+    @method _trackedDataChanged
     @private
   */
-  _sendDidTrack: Ember.observer('trackedData', function(){
+  _trackedDataChanged: Ember.observer('trackedData', function(){
+    var trackedData = this.get('trackedData');
+    this.set('hoverData', this._hovered ? trackedData : null);
+
     if(this.get('didTrack')) {
       this.sendAction('didTrack', {
-        x: this.get('trackedData.x'),
-        y: this.get('trackedData.y'),
-        data: this.get('trackedData.data'),
+        x: trackedData.x,
+        y: trackedData.y,
+        data: trackedData.data,
         source: this,
         graph: this.get('graph'),
       });

--- a/docs/classes/components.nf-area.html
+++ b/docs/classes/components.nf-area.html
@@ -166,7 +166,7 @@ sibling <code>nf-area</code> components to create a stacked graph.</p>
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method private inherited">
@@ -218,6 +218,10 @@ sibling <code>nf-area</code> components to create a stacked graph.</p>
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_graph">graph</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
 
                             </li>
                             <li class="index-item property">
@@ -282,6 +286,10 @@ sibling <code>nf-area</code> components to create a stacked graph.</p>
 
                             </li>
                             <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
+
+                            </li>
+                            <li class="index-item property inherited">
                                 <a href="#property_trackingDotRadius">trackingDotRadius</a>
 
                             </li>
@@ -322,8 +330,8 @@ sibling <code>nf-area</code> components to create a stacked graph.</p>
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -337,8 +345,8 @@ sibling <code>nf-area</code> components to create a stacked graph.</p>
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -742,6 +750,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_interpolator" class="property item">
                         <h3 class="name"><code>interpolator</code></h3>
                         <span class="type">String</span>
@@ -806,7 +851,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_lastVisibleData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l183"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:183</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l179"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:179</code></a>
                             </p>
                     
                     
@@ -1120,7 +1165,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -1132,6 +1177,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-bars.html
+++ b/docs/classes/components.nf-bars.html
@@ -163,7 +163,7 @@
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method private inherited">
@@ -238,6 +238,10 @@
 
                             </li>
                             <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
+                            <li class="index-item property inherited">
                                 <a href="#property_lastVisibleData">lastVisibleData</a>
 
                             </li>
@@ -263,6 +267,10 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -306,8 +314,8 @@
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -321,8 +329,8 @@
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -402,7 +410,7 @@ didTrack action.</p>
     <div class="meta">
                 <p>Inherited from
                 <a href="../classes/mixins.graph-data-graphic.html#method_getActualTrackData">mixins.graph-data-graphic</a>:
-        <a href="../files/addon_mixins_graph-data-graphic.js.html#l243"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:243</code></a>
+        <a href="../files/addon_mixins_graph-data-graphic.js.html#l235"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:235</code></a>
         </p>
 
 
@@ -839,6 +847,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_lastVisibleData" class="property item inherited">
                         <h3 class="name"><code>lastVisibleData</code></h3>
                         <span class="type">Object</span>
@@ -850,7 +895,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_lastVisibleData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l183"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:183</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l179"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:179</code></a>
                             </p>
                     
                     
@@ -1006,7 +1051,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -1018,6 +1063,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-crosshair.html
+++ b/docs/classes/components.nf-crosshair.html
@@ -159,7 +159,7 @@ while it's hovering over the graph content.</p>
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method inherited">
@@ -185,12 +185,20 @@ while it's hovering over the graph content.</p>
                                 <a href="#property_height">height</a>
 
                             </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
                             <li class="index-item property">
                                 <a href="#property_isVisible">isVisible</a>
 
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -222,8 +230,8 @@ while it's hovering over the graph content.</p>
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -237,8 +245,8 @@ while it's hovering over the graph content.</p>
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -370,6 +378,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_isVisible" class="property item">
                         <h3 class="name"><code>isVisible</code></h3>
                         <span class="type">Boolean</span>
@@ -407,7 +452,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -419,6 +464,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-dot.html
+++ b/docs/classes/components.nf-dot.html
@@ -159,7 +159,7 @@
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method inherited">
@@ -189,6 +189,10 @@
                                 <a href="#property_graph">graph</a>
 
                             </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
                             <li class="index-item property private">
                                 <a href="#property_isVisible">isVisible</a>
 
@@ -215,6 +219,10 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -250,8 +258,8 @@
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -265,8 +273,8 @@
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -418,6 +426,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         <div class="description">
                             <p>The parent graph for a component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
                     
                         </div>
                     
@@ -593,7 +638,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -605,6 +650,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-gg.html
+++ b/docs/classes/components.nf-gg.html
@@ -166,7 +166,7 @@ directions:</p>
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method inherited">
@@ -189,7 +189,15 @@ directions:</p>
 
                             </li>
                             <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
+                            <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -209,8 +217,8 @@ directions:</p>
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -224,8 +232,8 @@ directions:</p>
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -332,6 +340,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_showTrackingDot" class="property item inherited">
                         <h3 class="name"><code>showTrackingDot</code></h3>
                         <span class="type">Boolean</span>
@@ -343,7 +388,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -355,6 +400,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-graph-content.html
+++ b/docs/classes/components.nf-graph-content.html
@@ -157,7 +157,7 @@ the area where the graphics, such as lines will display.</p>
 
                     <ul class="index-list methods">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method inherited">
@@ -195,12 +195,20 @@ the area where the graphics, such as lines will display.</p>
                                 <a href="#property_hoverChange">hoverChange</a>
 
                             </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
                             <li class="index-item property">
                                 <a href="#property_hoverEnd">hoverEnd</a>
 
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -236,8 +244,8 @@ the area where the graphics, such as lines will display.</p>
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -251,8 +259,8 @@ the area where the graphics, such as lines will display.</p>
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -460,6 +468,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_hoverEnd" class="property item">
                         <h3 class="name"><code>hoverEnd</code></h3>
                         <span class="type">String</span>
@@ -497,7 +542,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -509,6 +554,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-horizontal-line.html
+++ b/docs/classes/components.nf-horizontal-line.html
@@ -159,7 +159,7 @@
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method inherited">
@@ -179,6 +179,10 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_graph">graph</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
 
                             </li>
                             <li class="index-item property private">
@@ -203,6 +207,10 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -242,8 +250,8 @@
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -257,8 +265,8 @@
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -358,6 +366,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         <div class="description">
                             <p>The parent graph for a component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
                     
                         </div>
                     
@@ -506,7 +551,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -518,6 +563,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-line.html
+++ b/docs/classes/components.nf-line.html
@@ -163,12 +163,12 @@
                     <h3>Methods</h3>
 
                     <ul class="index-list methods extends">
-                            <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
-
-                            </li>
                             <li class="index-item method private">
                                 <a href="#method__toggleSelected">_toggleSelected</a>
+
+                            </li>
+                            <li class="index-item method private inherited">
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method private inherited">
@@ -222,6 +222,10 @@
                                 <a href="#property_graph">graph</a>
 
                             </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
                             <li class="index-item property">
                                 <a href="#property_interpolator">interpolator</a>
 
@@ -268,6 +272,10 @@
 
                             </li>
                             <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
+
+                            </li>
+                            <li class="index-item property inherited">
                                 <a href="#property_trackingDotRadius">trackingDotRadius</a>
 
                             </li>
@@ -308,39 +316,6 @@
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
-
-        <span class="paren">()</span>
-
-
-
-        <span class="flag private">private</span>
-
-
-
-
-
-    <div class="meta">
-                <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>Observes changes to tracked data and sends the
-didTrack action.</p>
-
-    </div>
-
-
-
-
-</div>
 <div id="method__toggleSelected" class="method item private">
     <h3 class="name"><code>_toggleSelected</code></h3>
 
@@ -366,6 +341,39 @@ didTrack action.</p>
 
     <div class="description">
         <p>Event handler to toggle the <code>selected</code> property on click</p>
+
+    </div>
+
+
+
+
+</div>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
+
+        <span class="paren">()</span>
+
+
+
+        <span class="flag private">private</span>
+
+
+
+
+
+    <div class="meta">
+                <p>Inherited from
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Observes changes to tracked data and sends the
+didTrack action.</p>
 
     </div>
 
@@ -564,7 +572,7 @@ fires on <code>didInsertElement</code>.</p>
     <div class="meta">
                 <p>Inherited from
                 <a href="../classes/mixins.graph-data-graphic.html#method_getActualTrackData">mixins.graph-data-graphic</a>:
-        <a href="../files/addon_mixins_graph-data-graphic.js.html#l243"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:243</code></a>
+        <a href="../files/addon_mixins_graph-data-graphic.js.html#l235"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:235</code></a>
         </p>
 
 
@@ -864,6 +872,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_interpolator" class="property item">
                         <h3 class="name"><code>interpolator</code></h3>
                         <span class="type">String</span>
@@ -928,7 +973,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_lastVisibleData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l183"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:183</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l179"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:179</code></a>
                             </p>
                     
                     
@@ -1138,7 +1183,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -1150,6 +1195,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-plot.html
+++ b/docs/classes/components.nf-plot.html
@@ -159,7 +159,7 @@
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method inherited">
@@ -187,6 +187,10 @@
                             </li>
                             <li class="index-item property">
                                 <a href="#property_hasY">hasY</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
 
                             </li>
                             <li class="index-item property">
@@ -219,6 +223,10 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -258,8 +266,8 @@
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -273,8 +281,8 @@
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -428,6 +436,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         </div>
                     
+                    
+                    
+                    </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>
@@ -621,7 +666,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -633,6 +678,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-range-marker.html
+++ b/docs/classes/components.nf-range-marker.html
@@ -159,12 +159,12 @@ Should always be used in conjunction with an <code>nf-range-markers</code> conta
                     <h3>Methods</h3>
 
                     <ul class="index-list methods extends">
-                            <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
-
-                            </li>
                             <li class="index-item method private">
                                 <a href="#method__setup">_setup</a>
+
+                            </li>
+                            <li class="index-item method private inherited">
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method private">
@@ -200,6 +200,10 @@ Should always be used in conjunction with an <code>nf-range-markers</code> conta
                             </li>
                             <li class="index-item property">
                                 <a href="#property_height">height</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
 
                             </li>
                             <li class="index-item property">
@@ -244,6 +248,10 @@ Should always be used in conjunction with an <code>nf-range-markers</code> conta
                             </li>
                             <li class="index-item property">
                                 <a href="#property_totalHeight">totalHeight</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -295,39 +303,6 @@ Should always be used in conjunction with an <code>nf-range-markers</code> conta
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
-
-        <span class="paren">()</span>
-
-
-
-        <span class="flag private">private</span>
-
-
-
-
-
-    <div class="meta">
-                <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>Observes changes to tracked data and sends the
-didTrack action.</p>
-
-    </div>
-
-
-
-
-</div>
 <div id="method__setup" class="method item private">
     <h3 class="name"><code>_setup</code></h3>
 
@@ -354,6 +329,39 @@ didTrack action.</p>
     <div class="description">
         <p>Initialization function that registers the range marker with its parent
 and populates the container property</p>
+
+    </div>
+
+
+
+
+</div>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
+
+        <span class="paren">()</span>
+
+
+
+        <span class="flag private">private</span>
+
+
+
+
+
+    <div class="meta">
+                <p>Inherited from
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Observes changes to tracked data and sends the
+didTrack action.</p>
 
     </div>
 
@@ -557,6 +565,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> 10</p>
+                    
+                    
+                    </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>
@@ -804,7 +849,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -841,6 +886,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         </div>
                     
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-range-markers.html
+++ b/docs/classes/components.nf-range-markers.html
@@ -160,7 +160,7 @@ can be laid out in a manner in which they don't collide.</p>
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method inherited">
@@ -190,6 +190,10 @@ can be laid out in a manner in which they don't collide.</p>
                                 <a href="#property_graph">graph</a>
 
                             </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
                             <li class="index-item property">
                                 <a href="#property_isRangeMarkerContainer">isRangeMarkerContainer</a>
 
@@ -211,6 +215,10 @@ can be laid out in a manner in which they don't collide.</p>
 
                             </li>
                             <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
+
+                            </li>
+                            <li class="index-item property inherited">
                                 <a href="#property_trackingDotRadius">trackingDotRadius</a>
 
                             </li>
@@ -227,8 +235,8 @@ can be laid out in a manner in which they don't collide.</p>
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -242,8 +250,8 @@ can be laid out in a manner in which they don't collide.</p>
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -460,6 +468,43 @@ properties of it's neighboring components.</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_isRangeMarkerContainer" class="property item">
                         <h3 class="name"><code>isRangeMarkerContainer</code></h3>
                         <span class="type">Boolean</span>
@@ -578,7 +623,7 @@ properties of it's neighboring components.</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -590,6 +635,42 @@ properties of it's neighboring components.</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-right-tick.html
+++ b/docs/classes/components.nf-right-tick.html
@@ -173,7 +173,7 @@ on the right side of an <code>nf-graph</code>.</p>
 
                             </li>
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method private">
@@ -211,6 +211,10 @@ on the right side of an <code>nf-graph</code>.</p>
                                 <a href="#property_graph">graph</a>
 
                             </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
                             <li class="index-item property private">
                                 <a href="#property_isVisible">isVisible</a>
 
@@ -233,6 +237,10 @@ on the right side of an <code>nf-graph</code>.</p>
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -336,8 +344,8 @@ on the right side of an <code>nf-graph</code>.</p>
 
 
 </div>
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -351,8 +359,8 @@ on the right side of an <code>nf-graph</code>.</p>
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -581,6 +589,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_isVisible" class="property item private">
                         <h3 class="name"><code>isVisible</code></h3>
                         <span class="type">Unknown</span>
@@ -723,7 +768,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -735,6 +780,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-selection-box.html
+++ b/docs/classes/components.nf-selection-box.html
@@ -159,7 +159,7 @@
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method">
@@ -197,6 +197,10 @@
                                 <a href="#property_graph">graph</a>
 
                             </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
                             <li class="index-item property">
                                 <a href="#property_rectPath">rectPath</a>
 
@@ -219,6 +223,10 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -278,8 +286,8 @@
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -293,8 +301,8 @@
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -522,6 +530,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_rectPath" class="property item">
                         <h3 class="name"><code>rectPath</code></h3>
                         <span class="type">String</span>
@@ -662,7 +707,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -674,6 +719,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-svg-image.html
+++ b/docs/classes/components.nf-svg-image.html
@@ -161,7 +161,7 @@ uses the scale of the graph. Creates an <code>&lt;image class=&quot;nf-image&quo
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method private inherited">
@@ -189,6 +189,10 @@ uses the scale of the graph. Creates an <code>&lt;image class=&quot;nf-image&quo
                             </li>
                             <li class="index-item property">
                                 <a href="#property_height">height</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
 
                             </li>
                             <li class="index-item property deprecated inherited">
@@ -245,6 +249,10 @@ uses the scale of the graph. Creates an <code>&lt;image class=&quot;nf-image&quo
 
                             </li>
                             <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
+
+                            </li>
+                            <li class="index-item property inherited">
                                 <a href="#property_trackingDotRadius">trackingDotRadius</a>
 
                             </li>
@@ -281,8 +289,8 @@ uses the scale of the graph. Creates an <code>&lt;image class=&quot;nf-image&quo
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -296,8 +304,8 @@ uses the scale of the graph. Creates an <code>&lt;image class=&quot;nf-image&quo
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -459,6 +467,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                             <p>The height as a domain value. Does not
                     handle ordinal scales. To set a pixel value, just
                     set <code>svgHeight</code> directly.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
                     
                         </div>
                     
@@ -662,7 +707,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -799,6 +844,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         </div>
                     
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-svg-line.html
+++ b/docs/classes/components.nf-svg-line.html
@@ -160,7 +160,7 @@
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method private inherited">
@@ -184,6 +184,10 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_graph">graph</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
 
                             </li>
                             <li class="index-item property deprecated inherited">
@@ -236,6 +240,10 @@
 
                             </li>
                             <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
+
+                            </li>
+                            <li class="index-item property inherited">
                                 <a href="#property_trackingDotRadius">trackingDotRadius</a>
 
                             </li>
@@ -276,8 +284,8 @@
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -291,8 +299,8 @@
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -426,6 +434,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         <div class="description">
                             <p>The parent graph for a component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
                     
                         </div>
                     
@@ -629,7 +674,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -741,6 +786,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         </div>
                     
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-svg-path.html
+++ b/docs/classes/components.nf-svg-path.html
@@ -160,7 +160,7 @@
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method private inherited">
@@ -188,6 +188,10 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_graph">graph</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
 
                             </li>
                             <li class="index-item property deprecated inherited">
@@ -232,6 +236,10 @@
 
                             </li>
                             <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
+
+                            </li>
+                            <li class="index-item property inherited">
                                 <a href="#property_trackingDotRadius">trackingDotRadius</a>
 
                             </li>
@@ -256,8 +264,8 @@
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -271,8 +279,8 @@
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -431,6 +439,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         <div class="description">
                             <p>The parent graph for a component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
                     
                         </div>
                     
@@ -670,7 +715,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -707,6 +752,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         </div>
                     
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-svg-rect.html
+++ b/docs/classes/components.nf-svg-rect.html
@@ -161,7 +161,7 @@ to plot the rectangle, to allow for rectangles with &quot;negative&quot; heights
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method private inherited">
@@ -199,6 +199,10 @@ to plot the rectangle, to allow for rectangles with &quot;negative&quot; heights
                                 <a href="#property_height">height</a>
 
                             </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
                             <li class="index-item property deprecated inherited">
                                 <a href="#property_isSelected">isSelected</a>
 
@@ -230,6 +234,10 @@ to plot the rectangle, to allow for rectangles with &quot;negative&quot; heights
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -285,8 +293,8 @@ to plot the rectangle, to allow for rectangles with &quot;negative&quot; heights
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -300,8 +308,8 @@ to plot the rectangle, to allow for rectangles with &quot;negative&quot; heights
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -527,6 +535,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_isSelected" class="property item deprecated inherited">
                         <h3 class="name"><code>isSelected</code></h3>
                         <span class="type">Unknown</span>
@@ -723,7 +768,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -735,6 +780,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-tracker.html
+++ b/docs/classes/components.nf-tracker.html
@@ -158,7 +158,7 @@
 
                     <ul class="index-list methods">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method inherited">
@@ -193,6 +193,10 @@
 
                             </li>
                             <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
+                            <li class="index-item property inherited">
                                 <a href="#property_lastVisibleData">lastVisibleData</a>
 
                             </li>
@@ -218,6 +222,10 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -261,8 +269,8 @@
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -276,8 +284,8 @@
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -324,7 +332,7 @@ didTrack action.</p>
     <div class="meta">
                 <p>Inherited from
                 <a href="../classes/mixins.graph-data-graphic.html#method_getActualTrackData">mixins.graph-data-graphic</a>:
-        <a href="../files/addon_mixins_graph-data-graphic.js.html#l243"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:243</code></a>
+        <a href="../files/addon_mixins_graph-data-graphic.js.html#l235"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:235</code></a>
         </p>
 
 
@@ -531,6 +539,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_lastVisibleData" class="property item inherited">
                         <h3 class="name"><code>lastVisibleData</code></h3>
                         <span class="type">Object</span>
@@ -542,7 +587,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-data-graphic.html#property_lastVisibleData">mixins.graph-data-graphic</a>:
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l183"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:183</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l179"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:179</code></a>
                             </p>
                     
                     
@@ -698,7 +743,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -710,6 +755,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-vertical-line.html
+++ b/docs/classes/components.nf-vertical-line.html
@@ -159,7 +159,7 @@
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method inherited">
@@ -179,6 +179,10 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_graph">graph</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
 
                             </li>
                             <li class="index-item property private">
@@ -203,6 +207,10 @@
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -242,8 +250,8 @@
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -257,8 +265,8 @@
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -358,6 +366,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         <div class="description">
                             <p>The parent graph for a component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
                     
                         </div>
                     
@@ -506,7 +551,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -518,6 +563,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-x-axis.html
+++ b/docs/classes/components.nf-x-axis.html
@@ -175,7 +175,7 @@ default styling applied to them to position them appropriately based off of orie
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method inherited">
@@ -203,6 +203,10 @@ default styling applied to them to position them appropriately based off of orie
                             </li>
                             <li class="index-item property">
                                 <a href="#property_height">height</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
 
                             </li>
                             <li class="index-item property">
@@ -258,6 +262,10 @@ default styling applied to them to position them appropriately based off of orie
 
                             </li>
                             <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
+
+                            </li>
+                            <li class="index-item property inherited">
                                 <a href="#property_trackingDotRadius">trackingDotRadius</a>
 
                             </li>
@@ -302,8 +310,8 @@ default styling applied to them to position them appropriately based off of orie
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -317,8 +325,8 @@ default styling applied to them to position them appropriately based off of orie
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -473,6 +481,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> 20</p>
+                    
+                    
+                    </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>
@@ -642,7 +687,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -838,6 +883,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         </div>
                     
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-y-axis.html
+++ b/docs/classes/components.nf-y-axis.html
@@ -172,7 +172,7 @@ default styling applied to them to position them appropriately based off of orie
 
                     <ul class="index-list methods">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method inherited">
@@ -200,6 +200,10 @@ default styling applied to them to position them appropriately based off of orie
                             </li>
                             <li class="index-item property">
                                 <a href="#property_height">height</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
 
                             </li>
                             <li class="index-item property">
@@ -255,6 +259,10 @@ default styling applied to them to position them appropriately based off of orie
 
                             </li>
                             <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
+
+                            </li>
+                            <li class="index-item property inherited">
                                 <a href="#property_trackingDotRadius">trackingDotRadius</a>
 
                             </li>
@@ -299,8 +307,8 @@ default styling applied to them to position them appropriately based off of orie
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -314,8 +322,8 @@ default styling applied to them to position them appropriately based off of orie
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -469,6 +477,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         </div>
                     
+                    
+                    
+                    </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>
@@ -638,7 +683,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -833,6 +878,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                         </div>
                     
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/components.nf-y-diff.html
+++ b/docs/classes/components.nf-y-diff.html
@@ -167,7 +167,7 @@ due to default styling.</li>
 
                     <ul class="index-list methods extends">
                             <li class="index-item method private inherited">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method">
@@ -237,6 +237,10 @@ due to default styling.</li>
                                 <a href="#property_graph">graph</a>
 
                             </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
                             <li class="index-item property">
                                 <a href="#property_isOrientRight">isOrientRight</a>
 
@@ -267,6 +271,10 @@ due to default styling.</li>
                             </li>
                             <li class="index-item property inherited">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property inherited">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property inherited">
@@ -314,8 +322,8 @@ due to default styling.</li>
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private inherited">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private inherited">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -329,8 +337,8 @@ due to default styling.</li>
 
     <div class="meta">
                 <p>Inherited from
-                <a href="../classes/mixins.graph-has-graph-parent.html#method__sendDidTrack">mixins.graph-has-graph-parent</a>:
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                <a href="../classes/mixins.graph-has-graph-parent.html#method__trackedDataChanged">mixins.graph-has-graph-parent</a>:
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -774,6 +782,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item inherited">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_hoverData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_isOrientRight" class="property item">
                         <h3 class="name"><code>isOrientRight</code></h3>
                         <span class="type">Boolean</span>
@@ -965,7 +1010,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>Inherited from
                                     <a href="../classes/mixins.graph-has-graph-parent.html#property_showTrackingDot">mixins.graph-has-graph-parent</a>:
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -977,6 +1022,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item inherited">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>Inherited from
+                                    <a href="../classes/mixins.graph-has-graph-parent.html#property_trackedData">mixins.graph-has-graph-parent</a>:
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/classes/mixins.graph-data-graphic.html
+++ b/docs/classes/mixins.graph-data-graphic.html
@@ -237,7 +237,7 @@ for use in graphing components.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/addon_mixins_graph-data-graphic.js.html#l243"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:243</code></a>
+        <a href="../files/addon_mixins_graph-data-graphic.js.html#l235"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:235</code></a>
         </p>
 
 
@@ -370,7 +370,7 @@ This is overridden in nf-area to account for stacking of data.</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l183"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:183</code></a>
+                            <a href="../files/addon_mixins_graph-data-graphic.js.html#l179"><code>addon&#x2F;mixins&#x2F;graph-data-graphic.js:179</code></a>
                             </p>
                     
                     

--- a/docs/classes/mixins.graph-has-graph-parent.html
+++ b/docs/classes/mixins.graph-has-graph-parent.html
@@ -150,7 +150,7 @@ to a component that is to be contained in an <code>nf-graph</code>.</p>
 
                     <ul class="index-list methods">
                             <li class="index-item method private">
-                                <a href="#method__sendDidTrack">_sendDidTrack</a>
+                                <a href="#method__trackedDataChanged">_trackedDataChanged</a>
 
                             </li>
                             <li class="index-item method">
@@ -173,7 +173,15 @@ to a component that is to be contained in an <code>nf-graph</code>.</p>
 
                             </li>
                             <li class="index-item property">
+                                <a href="#property_hoverData">hoverData</a>
+
+                            </li>
+                            <li class="index-item property">
                                 <a href="#property_showTrackingDot">showTrackingDot</a>
+
+                            </li>
+                            <li class="index-item property">
+                                <a href="#property_trackedData">trackedData</a>
 
                             </li>
                             <li class="index-item property">
@@ -193,8 +201,8 @@ to a component that is to be contained in an <code>nf-graph</code>.</p>
             <div id="methods" class="api-class-tabpanel">
                 <h2 class="off-left">Methods</h2>
 
-<div id="method__sendDidTrack" class="method item private">
-    <h3 class="name"><code>_sendDidTrack</code></h3>
+<div id="method__trackedDataChanged" class="method item private">
+    <h3 class="name"><code>_trackedDataChanged</code></h3>
 
         <span class="paren">()</span>
 
@@ -209,7 +217,7 @@ to a component that is to be contained in an <code>nf-graph</code>.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+        <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l101"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:101</code></a>
         </p>
 
 
@@ -316,6 +324,43 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                     
                     
                     </div>
+                    <div id="property_hoverData" class="property item">
+                        <h3 class="name"><code>hoverData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>
+                                    Defined in
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l64"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:64</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component, ONLY if the
+                    graph-content is currently being hovered.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
+                    
+                    
+                    </div>
                     <div id="property_showTrackingDot" class="property item">
                         <h3 class="name"><code>showTrackingDot</code></h3>
                         <span class="type">Boolean</span>
@@ -327,7 +372,7 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         <div class="meta">
                                     <p>
                                     Defined in
-                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l48"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:48</code></a>
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l85"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:85</code></a>
                             </p>
                     
                     
@@ -339,6 +384,42 @@ NOTE: all object that mixin and have init, must call super.init()</p>
                         </div>
                     
                             <p><strong>Default:</strong> true</p>
+                    
+                    
+                    </div>
+                    <div id="property_trackedData" class="property item">
+                        <h3 class="name"><code>trackedData</code></h3>
+                        <span class="type">Object an object with the following values:  
+                      - point: an  x, y  pair for the exact px coordinates inside the graph-content
+                      - graphX: domain x value at mouse position
+                      - graphY: domain y value at mouse position
+                      - x: nearest x data value
+                      - y: nearest y data value
+                      - data: nearest raw data
+                      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+                      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+                      - mouseX: mouse x position in pixels
+                      - mouseY: mouse y position in pixels</span>
+                    
+                    
+                    
+                    
+                    
+                        <div class="meta">
+                                    <p>
+                                    Defined in
+                            <a href="../files/addon_mixins_graph-graphic-with-tracking-dot.js.html#l46"><code>addon&#x2F;mixins&#x2F;graph-graphic-with-tracking-dot.js:46</code></a>
+                            </p>
+                    
+                    
+                        </div>
+                    
+                        <div class="description">
+                            <p>The value of the data that is being tracked by the component.</p>
+                    
+                        </div>
+                    
+                            <p><strong>Default:</strong> null</p>
                     
                     
                     </div>

--- a/docs/data.json
+++ b/docs/data.json
@@ -1331,7 +1331,7 @@
         },
         {
             "file": "addon/mixins/graph-data-graphic.js",
-            "line": 183,
+            "line": 179,
             "description": "The last element from {{#crossLink \"mixins.graph-data-graphic/renderedData:property\"}}{{/crossLink}}\nthat is actually visible within the x domain.",
             "itemtype": "property",
             "name": "lastVisibleData",
@@ -1342,7 +1342,7 @@
         },
         {
             "file": "addon/mixins/graph-data-graphic.js",
-            "line": 243,
+            "line": 235,
             "description": "Gets the actual data at a rendered tracking point passed to it.\nThis is overridden in nf-area to account for stacking of data.",
             "itemtype": "method",
             "name": "getActualTrackData",
@@ -1405,7 +1405,29 @@
         },
         {
             "file": "addon/mixins/graph-graphic-with-tracking-dot.js",
-            "line": 48,
+            "line": 46,
+            "description": "The value of the data that is being tracked by the component.",
+            "itemtype": "property",
+            "name": "trackedData",
+            "type": "{Object} an object with the following values:  \n  - point: an { x, y } pair for the exact px coordinates inside the graph-content\n  - graphX: domain x value at mouse position\n  - graphY: domain y value at mouse position\n  - x: nearest x data value\n  - y: nearest y data value\n  - data: nearest raw data\n  - renderX: domain x value to render a tracking dot at (stacked areas are offset)\n  - renderY: domain x value to render a tracking dot at (stacked areas are offset)\n  - mouseX: mouse x position in pixels\n  - mouseY: mouse y position in pixels",
+            "default": "null",
+            "class": "mixins.graph-has-graph-parent",
+            "namespace": "mixins"
+        },
+        {
+            "file": "addon/mixins/graph-graphic-with-tracking-dot.js",
+            "line": 64,
+            "description": "The value of the data that is being tracked by the component, ONLY if the \ngraph-content is currently being hovered.",
+            "itemtype": "property",
+            "name": "hoverData",
+            "type": "{Object} an object with the following values:  \n  - point: an { x, y } pair for the exact px coordinates inside the graph-content\n  - graphX: domain x value at mouse position\n  - graphY: domain y value at mouse position\n  - x: nearest x data value\n  - y: nearest y data value\n  - data: nearest raw data\n  - renderX: domain x value to render a tracking dot at (stacked areas are offset)\n  - renderY: domain x value to render a tracking dot at (stacked areas are offset)\n  - mouseX: mouse x position in pixels\n  - mouseY: mouse y position in pixels",
+            "default": "null",
+            "class": "mixins.graph-has-graph-parent",
+            "namespace": "mixins"
+        },
+        {
+            "file": "addon/mixins/graph-graphic-with-tracking-dot.js",
+            "line": 85,
             "description": "Gets or sets whether the tracking dot should be shown at all.",
             "itemtype": "property",
             "name": "showTrackingDot",
@@ -1416,10 +1438,10 @@
         },
         {
             "file": "addon/mixins/graph-graphic-with-tracking-dot.js",
-            "line": 64,
+            "line": 101,
             "description": "Observes changes to tracked data and sends the\ndidTrack action.",
             "itemtype": "method",
-            "name": "_sendDidTrack",
+            "name": "_trackedDataChanged",
             "access": "private",
             "tagname": "",
             "class": "mixins.graph-has-graph-parent",

--- a/docs/files/addon_mixins_graph-data-graphic.js.html
+++ b/docs/files/addon_mixins_graph-data-graphic.js.html
@@ -284,16 +284,12 @@ export default Ember.Mixin.create({
         first = renderedData[1];
       }
 
-      var renderX = first[0];
-      var renderY = first[1];
-      var data = first.data;
-
       return first ? {
-        x: xPropFn(data),
-        y: yPropFn(data),
-        data,
-        renderX,
-        renderY
+        x: xPropFn(first.data),
+        y: yPropFn(first.data),
+        data: first.data,
+        renderX: first[0],
+        renderY: first[1]
       } : null;
     }
   }),
@@ -315,16 +311,12 @@ export default Ember.Mixin.create({
         last = renderedData[renderedData.length - 2];
       }
 
-      var data = last.data;
-      var renderX = last[0];
-      var renderY = last[1];
-
       return last ? {
-        x: xPropFn(data),
-        y: yPropFn(data),
-        data,
-        renderX,
-        renderY
+        x: xPropFn(last.data),
+        y: yPropFn(last.data),
+        data: last.data,
+        renderX: last[0],
+        renderY: last[1]
       }: null;
     }
   }),

--- a/docs/files/addon_mixins_graph-graphic-with-tracking-dot.js.html
+++ b/docs/files/addon_mixins_graph-graphic-with-tracking-dot.js.html
@@ -162,6 +162,43 @@ export default Ember.Mixin.create({
   */
   didTrack: null,
 
+  /**
+    The value of the data that is being tracked by the component.
+    @property trackedData
+    @type {Object} an object with the following values:  
+      - point: an { x, y } pair for the exact px coordinates inside the graph-content
+      - graphX: domain x value at mouse position
+      - graphY: domain y value at mouse position
+      - x: nearest x data value
+      - y: nearest y data value
+      - data: nearest raw data
+      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+      - mouseX: mouse x position in pixels
+      - mouseY: mouse y position in pixels
+    @default null
+  */
+  trackedData: null,
+
+  /**
+    The value of the data that is being tracked by the component, ONLY if the 
+    graph-content is currently being hovered.
+    @property hoverData
+    @type {Object} an object with the following values:  
+      - point: an { x, y } pair for the exact px coordinates inside the graph-content
+      - graphX: domain x value at mouse position
+      - graphY: domain y value at mouse position
+      - x: nearest x data value
+      - y: nearest y data value
+      - data: nearest raw data
+      - renderX: domain x value to render a tracking dot at (stacked areas are offset)
+      - renderY: domain x value to render a tracking dot at (stacked areas are offset)
+      - mouseX: mouse x position in pixels
+      - mouseY: mouse y position in pixels
+    @default null
+  */
+  hoverData: null,
+
   _showTrackingDot: true,
 
   /**
@@ -183,15 +220,18 @@ export default Ember.Mixin.create({
   /**
     Observes changes to tracked data and sends the
     didTrack action.
-    @method _sendDidTrack
+    @method _trackedDataChanged
     @private
   */
-  _sendDidTrack: Ember.observer(&#x27;trackedData&#x27;, function(){
+  _trackedDataChanged: Ember.observer(&#x27;trackedData&#x27;, function(){
+    var trackedData = this.get(&#x27;trackedData&#x27;);
+    this.set(&#x27;hoverData&#x27;, this._hovered ? trackedData : null);
+
     if(this.get(&#x27;didTrack&#x27;)) {
       this.sendAction(&#x27;didTrack&#x27;, {
-        x: this.get(&#x27;trackedData.x&#x27;),
-        y: this.get(&#x27;trackedData.y&#x27;),
-        data: this.get(&#x27;trackedData.data&#x27;),
+        x: trackedData.x,
+        y: trackedData.y,
+        data: trackedData.data,
         source: this,
         graph: this.get(&#x27;graph&#x27;),
       });
@@ -249,64 +289,87 @@ export default Ember.Mixin.create({
   _onHoverTrack() {
     var content = this._content;
 
-    var handler = e =&gt; {
+    var mousemoveHandler = e =&gt; {
+      this._hovered = true;
       var evt = this._getEventObject(e);
       this.set(&#x27;trackedData&#x27;, evt);
     };
 
-    content.on(&#x27;mousemove&#x27;, handler);
+    content.on(&#x27;mousemove&#x27;, mousemoveHandler);
 
     this._onHoverCleanup = () =&gt; {
-      content.off(&#x27;mousemove&#x27;, handler);
+      content.off(&#x27;mousemove&#x27;, mousemoveHandler);
     };
   },
+
+  _hovered: false,
 
   _onEndUntrack() {
     var content = this._content;
 
-    var handler = () =&gt; {
+    var mouseoutHandler = () =&gt; {
       this.set(&#x27;trackedData&#x27;, null);
     };
 
-    content.on(&#x27;mouseout&#x27;, handler);
+    content.on(&#x27;mouseout&#x27;, mouseoutHandler);
 
     this._onEndCleanup = () =&gt; {
-      content.off(&#x27;mouseout&#x27;, handler);
+      content.off(&#x27;mouseout&#x27;, mouseoutHandler);
     };
 
-    handler();
+    if(!this._hovered) {
+      this.set(&#x27;trackedData&#x27;, null);
+    }
   },
 
   _onEndSnapLast() {
     var content = this._content;
 
-    var handler = () =&gt; {
+    var mouseoutHandler = () =&gt; {
+      this._hovered = false;
       this.set(&#x27;trackedData&#x27;, this.get(&#x27;lastVisibleData&#x27;));
     };
 
-    content.on(&#x27;mouseout&#x27;, handler);
-
-    this._onEndCleanup = () =&gt; {
-      content.off(&#x27;mouseout&#x27;, handler);
+    var changeHandler = () =&gt; {
+      if(!this._hovered) {
+        this.set(&#x27;trackedData&#x27;, this.get(&#x27;lastVisibleData&#x27;));
+      }
     };
 
-    handler();
+    content.on(&#x27;mouseout&#x27;, mouseoutHandler);
+    this.addObserver(&#x27;lastVisibleData&#x27;, this, changeHandler);
+
+    this._onEndCleanup = () =&gt; {
+      content.off(&#x27;mouseout&#x27;, mouseoutHandler);
+      this.removeObserver(&#x27;lastVisibleData&#x27;, this, changeHandler);
+    };
+
+    changeHandler();
   },
 
   _onEndSnapFirst() {
     var content = this._content;
 
-    var handler = () =&gt; {
+    var mouseoutHandler = () =&gt; {
+      this._hovered = false;
       this.set(&#x27;trackedData&#x27;, this.get(&#x27;firstVisibleData&#x27;));
     };
 
-    content.on(&#x27;mouseout&#x27;, handler);
-
-    this._onEndCleanup = () =&gt; {
-      content.off(&#x27;mouseout&#x27;, handler);
+    var changeHandler = () =&gt; {
+      if(!this._hovered) {
+        this.set(&#x27;trackedData&#x27;, this.get(&#x27;firstVisibleData&#x27;));
+      }
     };
 
-    handler();
+    content.on(&#x27;mouseout&#x27;, mouseoutHandler);
+    this.addObserver(&#x27;firstVisibleData&#x27;, this, changeHandler);
+
+    this._onEndCleanup = () =&gt; {
+      content.off(&#x27;mouseout&#x27;, mouseoutHandler);
+      this.removeObserver(&#x27;firstVisibleData&#x27;, this, changeHandler);
+    };
+
+    changeHandler();
   },
 
   _trackingModeChanged: on(&#x27;init&#x27;, observer(&#x27;trackingMode&#x27;, &#x27;selected&#x27;, function() {
@@ -319,8 +382,19 @@ export default Ember.Mixin.create({
     var point = getMousePoint(content[0], e);
     var graphX = xScale.invert(point.x);
     var graphY = yScale.invert(point.y);
-    var { x, y, data, renderX, renderY } = this.getDataNearXRange(point.x);
+    var near = this.getDataNearXRange(point.x);
 
+    if(!near) {
+      return {
+        point,
+        graphX,
+        graphY,
+        mouseX: point.x,
+        mouseY: point.y,
+      };
+    }
+
+    var { x, y, data, renderX, renderY } = near;
     return {
       point,
       graphX,


### PR DESCRIPTION
We rediscovered a use case where we wanted the tracked data, but *only* while the graph was hovered, not when the trackedData was in a "snapped" position.