### PR TITLE
[BUGFIX] _unregister() is an Ember.View method that reclaims memory.

### DIFF
--- a/app/components/nf-area.js
+++ b/app/components/nf-area.js
@@ -75,7 +75,7 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
       };
     },
 
-    _unregister: Ember.on('willDestroyElement', function(){
+    _unregisterArea: Ember.on('willDestroyElement', function(){
       var stack = this.get('stack', stack);
       if(stack) {
         stack.unregisterArea(this);

--- a/app/components/nf-range-marker.js
+++ b/app/components/nf-range-marker.js
@@ -185,7 +185,7 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @method _unregister
     @private
   */
-  _unregister: Ember.on('willDestroyElement', function() {
+  _unregisterMarker: Ember.on('willDestroyElement', function() {
     this.get('container').unregisterMarker(this);
   })
 });


### PR DESCRIPTION
Overriding it causes leaks.

https://github.com/emberjs/ember.js/blob/7c008239182cce203f024768d3df999c2850f66f/packages/ember-views/lib/views/view.js#L1444