### PR TITLE
fix for #111, hasBlock only available from template

### DIFF
--- a/app/components/nf-x-axis.js
+++ b/app/components/nf-x-axis.js
@@ -41,11 +41,18 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
   layout: layout,
   template: null,
 
-  useTemplate: computed('hasBlock', 'template.blockParams', 'hasBlockParams', function(){
-    var preGlimmerCheck = this.get('template.blockParams');
-    var postGlimmerCheck = this.get('hasBlock') && this.get('hasBlockParams');
-    return Boolean(postGlimmerCheck || preGlimmerCheck);
-  }),
+  addTemplateObserver: function() {
+    this.addObserver('template.blockParams', this, function() {
+      var preGlimmer = this.get('template');
+      if (preGlimmer) {
+        if (!this.get('hasBlock')) {
+          this.set('hasBlock',computed('template.blockParams', function() {
+            return this.get('template.blockParams');
+          }));
+        }
+      }
+    });
+  },
 
   attributeBindings: ['transform'],
   classNameBindings: ['orientClass'],
@@ -183,6 +190,7 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
   init() {
     this._super(...arguments);
     this.set('graph.xAxis', this);
+    this.addTemplateObserver();
   },
 
   /**
@@ -225,7 +233,7 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     }
     else if(scaleType === 'ordinal') {
       return uniqueData;
-    } 
+    }
     else {
       return scale.ticks(tickCount);
     }

--- a/app/templates/components/nf-x-axis.hbs
+++ b/app/templates/components/nf-x-axis.hbs
@@ -2,7 +2,7 @@
 
 {{#each ticks as |tick|}}
   <g class="nf-x-axis-tick">
-    {{#if useTemplate}}
+    {{#if hasBlock}}
       {{#nf-tick-label x=tick.x y=tick.labely}}
         {{yield tick}}
       {{/nf-tick-label}}

--- a/tests/unit/app/components/nf-x-axis-test.js
+++ b/tests/unit/app/components/nf-x-axis-test.js
@@ -36,7 +36,7 @@ test('nf-x-axis tickData should call tickFactory if available', function(assert)
   });
 });
 
-test('nf-x-axis useTemplate if template.blockParams', function(assert) {
+test('nf-x-axis hasBlock if template.blockParams', function(assert) {
   Ember.run(() => {
     var axis = this.factory().extend({
       graph: Ember.computed((key, value) => ({
@@ -48,21 +48,22 @@ test('nf-x-axis useTemplate if template.blockParams', function(assert) {
       blockParams: true
     }));
 
-    assert.equal(axis.get('useTemplate'), true);
+    assert.equal(axis.get('hasBlock'), true);
   });
 });
 
 
-test('nf-x-axis useTemplate if hasBlock AND hasBlockParams', function(assert) {
+test('nf-x-axis hasBlock if template is undefined', function(assert) {
   Ember.run(() => {
     var axis = this.factory().extend({
       graph: Ember.computed((key, value) => ({
         xScaleType: 'xScaleType'
       })),
-      hasBlock: true,
-      hasBlockParams: true
+
+      hasBlock: true
     }).create();
 
-    assert.equal(axis.get('useTemplate'), true);
+    assert.equal(axis.get('template'), undefined);
+    assert.equal(axis.get('hasBlock'), true);
   });
 });


### PR DESCRIPTION
we add an observer if template exists (preGlimmer) that sets `hasBlock`
to the value of `template.blockParams`, otherwise we do what ember would
normally do, post-glimmer