### PR TITLE
Add "demoURL" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "https://netflix.github.io/ember-nf-graph-examples/dist/"
   }
 }


### PR DESCRIPTION
Sites likes emberaddons.com and emberobserver.com will display a link to "demoURL".